### PR TITLE
[NET-460] Follow search references

### DIFF
--- a/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
+++ b/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
@@ -18,7 +18,7 @@
           <div class="custom-control custom-checkbox">
             <input (change)="onResolveChange($event)" type="checkbox" class="custom-control-input" id="search-result-bar-follow-objects-button">
             <label for="search-result-bar-follow-objects-button" class="custom-control-label">
-              Follow object references
+              References
             </label>
           </div>
         </div>

--- a/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
+++ b/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
@@ -1,7 +1,7 @@
 
 <div class="container-fluid">
   <div class="row object-view-navbar">
-    <div class="col-3">
+    <div class="col-2">
       <div class="d-flex justify-content-start">
         <div class="icon"><i class="far fa-list-alt"></i></div>
         <div class="name">
@@ -10,7 +10,21 @@
         </div>
       </div>
     </div>
-    <div class="col-7 border-left d-flex justify-content-start">
+    <div class="col-2 border-left">
+      <div class="d-flex justify-content-start">
+        <div class="icon"><i class="fas fa-puzzle-piece"></i></div>
+        <div class="name">
+          <strong class="text-uppercase">Resolve</strong>
+          <div class="custom-control custom-checkbox">
+            <input (change)="onResolveChange($event)" type="checkbox" class="custom-control-input" id="search-result-bar-follow-objects-button">
+            <label for="search-result-bar-follow-objects-button" class="custom-control-label">
+              Follow object references
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 border-left d-flex justify-content-start">
       <div class="d-flex">
         <div class="icon"><i class="fas fa-filter mr-1"></i></div>
         <div class="name"><strong class="text-uppercase">Filter</strong>

--- a/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
+++ b/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
@@ -17,7 +17,7 @@
           <strong class="text-uppercase">Resolve</strong>
           <div class="custom-control custom-checkbox">
             <input (change)="onResolveChange($event)" type="checkbox" class="custom-control-input"
-                   id="search-result-bar-follow-objects-button" [checked]="resolve.value">
+                   id="search-result-bar-follow-objects-button" [checked]="resolve.value" [disabled]="!resolve.value && searchResultList?.total_results > 20">
             <label for="search-result-bar-follow-objects-button" class="custom-control-label">
               References
             </label>

--- a/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
+++ b/app/src/app/search/search-result/search-result-bar/search-result-bar.component.html
@@ -16,7 +16,8 @@
         <div class="name">
           <strong class="text-uppercase">Resolve</strong>
           <div class="custom-control custom-checkbox">
-            <input (change)="onResolveChange($event)" type="checkbox" class="custom-control-input" id="search-result-bar-follow-objects-button">
+            <input (change)="onResolveChange($event)" type="checkbox" class="custom-control-input"
+                   id="search-result-bar-follow-objects-button" [checked]="resolve.value">
             <label for="search-result-bar-follow-objects-button" class="custom-control-label">
               References
             </label>

--- a/app/src/app/search/search-result/search-result-bar/search-result-bar.component.ts
+++ b/app/src/app/search/search-result/search-result-bar/search-result-bar.component.ts
@@ -1,4 +1,13 @@
-import { Component, EventEmitter, HostListener, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 import { ToastService } from '../../../layout/toast/toast.service';
 import { SearchResultList } from '../../models/search-result';
 import { BehaviorSubject } from 'rxjs';
@@ -36,11 +45,13 @@ export class SearchResultBarComponent implements OnInit, OnChanges {
   public ngOnInit(): void {
     this.rollbackQueryParameters = this.queryParameters;
     this.addPreSelectedFilterItem(this.queryParameters);
+
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
     this.preSelectedFilterList = [];
     this.addPreSelectedFilterItem(this.queryParameters);
+
   }
 
   @HostListener('window:scroll')
@@ -130,6 +141,9 @@ export class SearchResultBarComponent implements OnInit, OnChanges {
     const baseUrl = parsedUrl.origin;
     const selBox = document.createElement('textarea');
     selBox.value = `${ baseUrl }/search?query=${ this.queryParameters }`;
+    if (this.resolve.value) {
+      selBox.value = selBox.value + `&resolve=${ this.resolve.value }`;
+    }
     this.generateDataForClipboard(selBox);
   }
 

--- a/app/src/app/search/search.component.html
+++ b/app/src/app/search/search.component.html
@@ -1,7 +1,8 @@
-
+{{resolve.value}}
 <cmdb-search-result-bar [queryParameters]="queryParameters"
                         [searchResultList]="searchResultList"
                         [filterResultList]="filterResultList"
+                        [resolve]="resolve"
                         (refreshSearch)="reSearch($event)"></cmdb-search-result-bar>
 
 <hr/>

--- a/app/src/app/search/search.component.html
+++ b/app/src/app/search/search.component.html
@@ -18,3 +18,6 @@
     </ng-container>
   </div>
 </div>
+<pre>
+{{searchResultList | json}}
+</pre>

--- a/app/src/app/search/search.component.html
+++ b/app/src/app/search/search.component.html
@@ -18,6 +18,3 @@
     </ng-container>
   </div>
 </div>
-<pre>
-{{searchResultList | json}}
-</pre>

--- a/app/src/app/search/search.component.html
+++ b/app/src/app/search/search.component.html
@@ -1,4 +1,3 @@
-{{resolve.value}}
 <cmdb-search-result-bar [queryParameters]="queryParameters"
                         [searchResultList]="searchResultList"
                         [filterResultList]="filterResultList"

--- a/app/src/app/search/search.component.ts
+++ b/app/src/app/search/search.component.ts
@@ -102,10 +102,9 @@ export class SearchComponent implements OnInit, OnDestroy {
    * Constructor of SearchComponent
    *
    * @param route Current activated route.
-   * @param spinner Spinner service.
    * @param searchService API Search service.
    */
-  constructor(private route: ActivatedRoute, private spinner: NgxSpinnerService, private searchService: SearchService) {
+  constructor(private route: ActivatedRoute, private searchService: SearchService) {
     this.searchInputForm = new FormGroup({
       input: new FormControl('', Validators.required)
     });
@@ -116,7 +115,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     this.route.queryParamMap.pipe(takeUntil(this.subscriber)).subscribe(params => {
       this.queryParameters = params.get('query');
       if (params.has('resolve')) {
-        this.resolve = JSON.parse(params.get('resolve'));
+        this.resolve.next(JSON.parse(params.get('resolve')));
       }
       this.initSearch = true;
       this.initFilter = true;
@@ -132,7 +131,6 @@ export class SearchComponent implements OnInit, OnDestroy {
    * Triggers the actual search api call.
    */
   public onSearch(): void {
-    this.spinner.show();
     let params = new HttpParams();
     params = params.set('limit', this.limit.toString());
     params = params.set('skip', this.skip.toString());
@@ -147,7 +145,6 @@ export class SearchComponent implements OnInit, OnDestroy {
         this.initSearch = false;
         this.initFilter = false;
       }
-      this.spinner.hide();
     });
   }
 

--- a/cmdb/interface/rest_api/search_routes.py
+++ b/cmdb/interface/rest_api/search_routes.py
@@ -95,7 +95,7 @@ def search_framework(request_user: User):
 
         searcher = SearcherFramework(manager=object_manager)
         result = searcher.aggregate(pipeline=query, request_user=request_user, limit=limit, skip=skip,
-                                    resolve=resolve_object_references)
+                                    resolve=resolve_object_references, active=only_active)
 
     except Exception as err:
         LOGGER.error(f'[Search Framework Rest]: {err}')

--- a/cmdb/interface/rest_api/search_routes.py
+++ b/cmdb/interface/rest_api/search_routes.py
@@ -87,15 +87,16 @@ def search_framework(request_user: User):
     except Exception as err:
         LOGGER.error(f'[Search Framework]: {err}')
         return abort(400, err)
-
     try:
         builder = PipelineBuilder()
         search_parameters = SearchParam.from_request(search_params)
+
         query: Pipeline = builder.build(search_parameters, object_manager, only_active)
 
         searcher = SearcherFramework(manager=object_manager)
-        result = searcher.aggregate(pipeline=query, request_user=request_user, limit=limit, skip=skip)
-        LOGGER.debug(result.__dict__)
+        result = searcher.aggregate(pipeline=query, request_user=request_user, limit=limit, skip=skip,
+                                    resolve=resolve_object_references)
+
     except Exception as err:
         LOGGER.error(f'[Search Framework Rest]: {err}')
         return make_response([], 204)

--- a/cmdb/interface/rest_api/search_routes.py
+++ b/cmdb/interface/rest_api/search_routes.py
@@ -74,6 +74,7 @@ def search_framework(request_user: User):
         skip = request.args.get('skip', Search.DEFAULT_SKIP, int)
         only_active = _fetch_only_active_objs()
         search_params: dict = request.args.get('query') or '{}'
+        resolve_object_references: bool = request.args.get('resolve', False)
     except ValueError as err:
         return abort(400, err)
     try:

--- a/cmdb/search/query/builder.py
+++ b/cmdb/search/query/builder.py
@@ -159,6 +159,18 @@ class Builder:
         return {'$lookup': {'from': _from, 'localField': _local, 'foreignField': _foreign, 'as': _as}}
 
     @classmethod
+    def lookup_sub_(cls, from_: str, let_: dict, pipeline_: list, as_: str) -> dict:
+        """ Performs uncorrelated subqueries between two collections as well as allow other join conditions besides a
+            single equality match, the $lookup stage has the following syntax.
+            Args:
+                from_:      Specifies the collection in the same database to perform the join with.
+                let_:       Optional. Specifies variables to use in the pipeline field stages.
+                pipeline_:  The pipeline determines the resulting documents from the joined collection.
+                as_:        Specifies the name of the new array field to add to the input documents.
+            """
+        return {'$lookup': {'from': from_, 'let': let_, 'pipeline': pipeline_, 'as': as_}}
+
+    @classmethod
     def unwind_(cls, path: str):
         """Duplicates each document in the pipeline, once per array element."""
         return {'$unwind': path}

--- a/cmdb/search/search_result.py
+++ b/cmdb/search/search_result.py
@@ -14,12 +14,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import logging
-from typing import TypeVar, Generic, List, Union
+from typing import TypeVar, Generic, List
 
 from bson import Regex
-
-from cmdb.framework import CmdbObject
-from cmdb.framework.cmdb_render import RenderResult
 
 LOGGER = logging.getLogger(__name__)
 R: TypeVar = TypeVar('R')

--- a/cmdb/search/search_result.py
+++ b/cmdb/search/search_result.py
@@ -14,9 +14,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import logging
-from typing import TypeVar, Generic, List
+from typing import TypeVar, Generic, List, Union
 
 from bson import Regex
+
+from cmdb.framework import CmdbObject
+from cmdb.framework.cmdb_render import RenderResult
 
 LOGGER = logging.getLogger(__name__)
 R: TypeVar = TypeVar('R')
@@ -35,16 +38,38 @@ class SearchResultMap(Generic[R]):
         return {'result': self.result.__dict__, 'matches': self.matches}
 
 
+class SearchReferenceResults:
+
+    def __init__(self, object_id: int, objects: List[Union[CmdbObject, RenderResult]] = None):
+        """
+        Constructor of SearchReferenceResults
+
+        Args:
+            object_id: ID of the referenced object
+            objects: List of objects which references to the object with the object_id
+        """
+        self.object_id = object_id
+        self.objects = objects or []
+
+    def to_dict(self) -> dict:
+        return {
+            'object_id': self.object_id,
+            'objects': self.objects
+        }
+
+
 class SearchResult(Generic[R]):
     """Generic search result base"""
 
-    def __init__(self, results: List[R], total_results: int, groups: List[R], alive: bool, limit: int, skip: int,
-                 matches_regex: List[str] = None):
+    def __init__(self, results: List[R], total_results: int, groups: list, alive: bool, limit: int, skip: int,
+                 references: List[SearchReferenceResults] = None, matches_regex: List[str] = None):
         """
         Constructor for search result
         Args:
             results: List of generic search results
             total_results: total number of results
+            groups: Type groups of objects
+            references: List of resolved references
             alive: flag if spliced search result has more data in database
             limit: max number of results to return
             skip: start of index value for the search
@@ -55,6 +80,7 @@ class SearchResult(Generic[R]):
         self.total_results: int = total_results
         self.alive = alive
         self.groups = groups
+        self.references: List[SearchReferenceResults] = references or []
         self.results: List[SearchResultMap] = [
             SearchResultMap[R](result=result, matches=self.find_match_fields(result, matches_regex)) for result in
             results]
@@ -103,6 +129,7 @@ class SearchResult(Generic[R]):
             'limit': self.limit,
             'skip': self.skip,
             'groups': self.groups,
+            'references': [reference.to_dict() for reference in self.references],
             'total_results': self.total_results,
             'number_of_results': len(self),
             'results': self.results

--- a/cmdb/search/search_result.py
+++ b/cmdb/search/search_result.py
@@ -38,38 +38,16 @@ class SearchResultMap(Generic[R]):
         return {'result': self.result.__dict__, 'matches': self.matches}
 
 
-class SearchReferenceResults:
-
-    def __init__(self, object_id: int, objects: List[Union[CmdbObject, RenderResult]] = None):
-        """
-        Constructor of SearchReferenceResults
-
-        Args:
-            object_id: ID of the referenced object
-            objects: List of objects which references to the object with the object_id
-        """
-        self.object_id = object_id
-        self.objects = objects or []
-
-    def to_dict(self) -> dict:
-        return {
-            'object_id': self.object_id,
-            'objects': self.objects
-        }
-
-
 class SearchResult(Generic[R]):
     """Generic search result base"""
 
-    def __init__(self, results: List[R], total_results: int, groups: list, alive: bool, limit: int, skip: int,
-                 references: List[SearchReferenceResults] = None, matches_regex: List[str] = None):
+    def __init__(self, results: List[R], total_results: int, groups: list, alive: bool, limit: int, skip: int, matches_regex: List[str] = None):
         """
         Constructor for search result
         Args:
             results: List of generic search results
             total_results: total number of results
             groups: Type groups of objects
-            references: List of resolved references
             alive: flag if spliced search result has more data in database
             limit: max number of results to return
             skip: start of index value for the search
@@ -80,7 +58,6 @@ class SearchResult(Generic[R]):
         self.total_results: int = total_results
         self.alive = alive
         self.groups = groups
-        self.references: List[SearchReferenceResults] = references or []
         self.results: List[SearchResultMap] = [
             SearchResultMap[R](result=result, matches=self.find_match_fields(result, matches_regex)) for result in
             results]
@@ -129,7 +106,6 @@ class SearchResult(Generic[R]):
             'limit': self.limit,
             'skip': self.skip,
             'groups': self.groups,
-            'references': [reference.to_dict() for reference in self.references],
             'total_results': self.total_results,
             'number_of_results': len(self),
             'results': self.results

--- a/cmdb/search/searchers.py
+++ b/cmdb/search/searchers.py
@@ -23,7 +23,7 @@ from cmdb.framework.cmdb_render import RenderResult, RenderList
 from cmdb.search import Search
 from cmdb.search.query import Query, Pipeline
 from cmdb.search.query.pipe_builder import PipelineBuilder
-from cmdb.search.search_result import SearchResult
+from cmdb.search.search_result import SearchResult, SearchReferenceResults
 from cmdb.user_management import User
 
 LOGGER = logging.getLogger(__name__)
@@ -53,12 +53,39 @@ class SearcherFramework(Search[CmdbObjectManager]):
         plb = PipelineBuilder(pipeline)
 
         # define search output
-        stages: dict = {
-            'metadata': [PipelineBuilder.count_('total')],
-            'data': [
-                PipelineBuilder.skip_(skip),
-                PipelineBuilder.limit_(limit)
-            ],
+        stages: dict = {}
+        stages.update({'metadata': [PipelineBuilder.count_('total')]})
+        stages.update({'data': [
+            PipelineBuilder.skip_(skip),
+            PipelineBuilder.limit_(limit)
+        ]})
+
+        if kwargs.get('resolve', False):
+            references_stage: dict = {
+                'references': [
+                    PipelineBuilder.lookup_sub_(
+                        'framework.objects',
+                        {'ref_id': '$public_id'},
+                        [{'$match': {'$expr': {'$in': ['$$ref_id', '$fields.value']}}}],
+                        'ref_data'),
+                    PipelineBuilder.unwind_(path='$ref_data'),
+                    PipelineBuilder.project_(specification={
+                        '_id': 0,
+                        'public_id': 1,
+                        'ref_data': 1
+                    }),
+                    {'$group': {
+                        '_id': '$$ROOT.public_id',
+                        'objects': {'$push': '$ref_data'},
+                        'total': {
+                            '$sum': 1
+                        }
+                    }}
+                ]
+            }
+            stages.update(references_stage)
+
+        group_stage: dict = {
             'group': [
                 PipelineBuilder.lookup_(TypeModel.COLLECTION, 'type_id', 'public_id', 'lookup_data'),
                 PipelineBuilder.unwind_('$lookup_data'),
@@ -75,6 +102,8 @@ class SearcherFramework(Search[CmdbObjectManager]):
                 PipelineBuilder.sort_("total", -1)
             ]
         }
+        stages.update(group_stage)
+
         plb.add_pipe(PipelineBuilder.facet_(stages))
 
         raw_search_result = self.manager.aggregate(collection=CmdbObject.COLLECTION, pipeline=plb.pipeline)
@@ -91,8 +120,22 @@ class SearcherFramework(Search[CmdbObjectManager]):
             pre_rendered_result_list = [CmdbObject(**raw_result) for raw_result in raw_search_result_list_entry['data']]
             rendered_result_list = RenderList(pre_rendered_result_list, request_user,
                                               object_manager=self.manager).render_result_list()
+
             total_results = raw_search_result_list_entry['metadata'][0].get('total', 0)
             group_result_list = raw_search_result_list[0]['group']
+            rendered_reference_list = []
+            if kwargs.get('resolve', False):
+                raw_reference_results = raw_search_result_list[0]['references']
+                reference_results: List[SearchReferenceResults] = []
+
+                for reference_group in raw_reference_results:
+                    reference_group_objects = [CmdbObject(**raw_result) for raw_result in
+                                               reference_group.get('objects', [])]
+                    rendered_reference_list = RenderList(reference_group_objects, request_user,
+                                                         object_manager=self.manager).render_result_list()
+                    reference_results.append(
+                        SearchReferenceResults(reference_group.get('_id'), rendered_reference_list))
+                rendered_reference_list = reference_results
         else:
             rendered_result_list = []
             group_result_list = []
@@ -102,6 +145,7 @@ class SearcherFramework(Search[CmdbObjectManager]):
             results=rendered_result_list,
             total_results=total_results,
             groups=group_result_list,
+            references=rendered_reference_list,
             alive=raw_search_result.alive,
             matches_regex=matches_regex,
             limit=limit,


### PR DESCRIPTION
## Description
A reference is now a content of a object in the search mode

## Related JIRA-Code
[https://nethinks.atlassian.net/browse/NET-460](https://nethinks.atlassian.net/browse/NET-460)

## Motivation and Context
Have a look at the following situation:
- object type “location“ is defined with a few fields like city, street, country, name
- object type “server“ is defined with a reference field to a location object

If a user will search for a location name (which is a field of a location object) in a current version of DATAGERRY, only the location will be found. The server object can not be found.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
