### PR TITLE
[NET-656] Last object editor

### DIFF
--- a/app/src/app/dashboard/dashboard.component.ts
+++ b/app/src/app/dashboard/dashboard.component.ts
@@ -132,6 +132,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
       cssClasses: ['text-center']
     } as Column;
 
+    const editorColumn = {
+      display: 'Last editor',
+      name: 'editor_id',
+      data: 'object_information.editor_name',
+      sortable: false,
+      searchable: false,
+      cssClasses: ['text-center'],
+      render(data: any) {
+        if (!data) {
+          return '';
+        }
+        return data;
+      }
+    } as Column;
+
     const creationColumn = {
       display: 'Creation Time',
       name: 'creation_time',
@@ -170,7 +185,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       style: { width: '6em' }
     } as unknown as Column;
     this.newestTableColumns = [activeColumn, publicColumn, typeColumn, authorColumn, creationColumn, actionColumn];
-    this.latestTableColumns = [activeColumn, publicColumn, typeColumn, authorColumn, lastModColumn, actionColumn];
+    this.latestTableColumns = [activeColumn, publicColumn, typeColumn, editorColumn, lastModColumn, actionColumn];
 
     this.objectService.countObjects().subscribe((totals) => {
       this.objectCount = totals;
@@ -230,14 +245,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   private generateTypeChar() {
-    const apiParameters: CollectionParameters = { page: 1, limit: 5, sort: 'public_id', order: 1};
+    const apiParameters: CollectionParameters = { page: 1, limit: 5, sort: 'public_id', order: 1 };
     this.categoryService.getCategoryIteration(apiParameters).pipe(
       takeUntil(this.unSubscribe)).subscribe((response: APIGetMultiResponse<CmdbCategory>) => {
-        for (const category of response.results) {
-          this.labelsCategory.push(category.label);
-          this.colorsCategory.push(this.getRandomColor());
-          this.itemsCategory.push(category.types.length);
-        }
+      for (const category of response.results) {
+        this.labelsCategory.push(category.label);
+        this.colorsCategory.push(this.getRandomColor());
+        this.itemsCategory.push(category.types.length);
+      }
     });
   }
 
@@ -270,16 +285,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public onObjectDelete(value: RenderResult) {
     this.objectService.deleteObject(value.object_information.object_id).pipe(takeUntil(this.unSubscribe))
       .subscribe(() => {
-        this.toastService.success(`Object ${ value.object_information.object_id } was deleted successfully`);
-        this.sidebarService.updateTypeCounter(value.type_information.type_id).then(() => {
-            this.loadLatestObjects();
-            this.loadNewstObjects();
-          }
-        );
-      },
-      (error) => {
-        this.toastService.error(`Error while deleting object ${ value.object_information.object_id } | Error: ${ error }`);
-      });
+          this.toastService.success(`Object ${ value.object_information.object_id } was deleted successfully`);
+          this.sidebarService.updateTypeCounter(value.type_information.type_id).then(() => {
+              this.loadLatestObjects();
+              this.loadNewstObjects();
+            }
+          );
+        },
+        (error) => {
+          this.toastService.error(`Error while deleting object ${ value.object_information.object_id } | Error: ${ error }`);
+        });
   }
 
   public ngOnDestroy(): void {

--- a/app/src/app/framework/models/cmdb-object.ts
+++ b/app/src/app/framework/models/cmdb-object.ts
@@ -27,6 +27,7 @@ export class CmdbObject implements CmdbDao {
   public status: boolean = true;
   public version: string;
   public author_id: number;
+  public editor_id?: number;
   public active: boolean;
   public fields: any[];
   public creation_time: any;

--- a/app/src/app/framework/models/cmdb-render.ts
+++ b/app/src/app/framework/models/cmdb-render.ts
@@ -33,6 +33,8 @@ export class RenderResult {
     },
     author_id: number;
     author_name: string;
+    editor_id?: number;
+    editor_name?: string;
     active: boolean;
     version: string;
   };

--- a/cmdb/framework/cmdb_object.py
+++ b/cmdb/framework/cmdb_object.py
@@ -43,8 +43,8 @@ class CmdbObject(CmdbDAO):
         'version'
     ]
 
-    def __init__(self, type_id, creation_time, author_id, active, fields, last_edit_time=None, status: int = None,
-                 version: str = '1.0.0', **kwargs):
+    def __init__(self, type_id, creation_time, author_id, active, fields, last_edit_time=None, editor_id: int = None,
+                 status: int = None, version: str = '1.0.0', **kwargs):
         """init of object
 
         Args:
@@ -53,6 +53,7 @@ class CmdbObject(CmdbDAO):
             creation_time: date of object creation
             author_id: public id of author
             last_edit_time: last date of editing
+            editor_id: id of the last editor
             active: object activation status
             fields: data inside fields
             **kwargs: additional data
@@ -63,6 +64,7 @@ class CmdbObject(CmdbDAO):
         self.creation_time = creation_time
         self.author_id = author_id
         self.last_edit_time = last_edit_time
+        self.editor_id = editor_id
         self.active = active
         self.fields = fields
         super(CmdbObject, self).__init__(**kwargs)
@@ -81,6 +83,7 @@ class CmdbObject(CmdbDAO):
             creation_time=data.get('creation_time'),
             author_id=data.get('author_id'),
             last_edit_time=data.get('last_edit_time', None),
+            editor_id=data.get('editor_id', None),
             active=data.get('active'),
             fields=data.get('fields', []),
             public_id=data.get('public_id')

--- a/cmdb/framework/cmdb_object_manager.py
+++ b/cmdb/framework/cmdb_object_manager.py
@@ -258,6 +258,7 @@ class CmdbObjectManager(CmdbManagerBase):
 
     def update_object(self, data: (dict, CmdbObject), user: UserModel = None,
                       permission: AccessControlPermission = None) -> str:
+
         if isinstance(data, dict):
             update_object = CmdbObject(**data)
         elif isinstance(data, CmdbObject):
@@ -265,6 +266,8 @@ class CmdbObjectManager(CmdbManagerBase):
         else:
             raise ObjectManagerUpdateError('Wrong CmdbObject init format - expecting CmdbObject or dict')
         update_object.last_edit_time = datetime.utcnow()
+        if user:
+            update_object.editor_id = user.public_id
 
         type_ = self._type_manager.get(update_object.type_id)
         verify_access(type_, user, permission)

--- a/cmdb/framework/cmdb_render.py
+++ b/cmdb/framework/cmdb_render.py
@@ -82,7 +82,7 @@ class CmdbRender:
         self.dt_render = dt_render
         self.ref_render = ref_render
 
-    def _render_username_by_id(self, user_id: int) -> str:
+    def _render_username_by_id(self, user_id: int, default=AUTHOR_ANONYMOUS_NAME) -> str:
         user: UserModel = None
         try:
             user = next(_ for _ in self.user_list if _.public_id == user_id)
@@ -91,7 +91,7 @@ class CmdbRender:
         if user:
             return user.get_display_name()
         else:
-            return CmdbRender.AUTHOR_ANONYMOUS_NAME
+            return default
 
     @property
     def object_instance(self) -> CmdbObject:
@@ -151,16 +151,16 @@ class CmdbRender:
     def __generate_object_information(self, render_result: RenderResult) -> RenderResult:
         try:
             author_name = self._render_username_by_id(self.object_instance.author_id)
-        except CMDBError as err:
+        except CMDBError:
             author_name = CmdbRender.AUTHOR_ANONYMOUS_NAME
 
         if self.object_instance.editor_id:
             try:
                 editor_name = self._render_username_by_id(self.object_instance.editor_id)
             except CMDBError:
-                editor_name = CmdbRender.AUTHOR_ANONYMOUS_NAME
+                editor_name = None
         else:
-            editor_name = CmdbRender.AUTHOR_ANONYMOUS_NAME
+            editor_name = None
 
         render_result.object_information = {
             'object_id': self.object_instance.get_public_id(),

--- a/cmdb/framework/cmdb_render.py
+++ b/cmdb/framework/cmdb_render.py
@@ -153,13 +153,23 @@ class CmdbRender:
             author_name = self._render_username_by_id(self.object_instance.author_id)
         except CMDBError as err:
             author_name = CmdbRender.AUTHOR_ANONYMOUS_NAME
-            LOGGER.error(err.message)
+
+        if self.object_instance.editor_id:
+            try:
+                editor_name = self._render_username_by_id(self.object_instance.editor_id)
+            except CMDBError:
+                editor_name = CmdbRender.AUTHOR_ANONYMOUS_NAME
+        else:
+            editor_name = CmdbRender.AUTHOR_ANONYMOUS_NAME
+
         render_result.object_information = {
             'object_id': self.object_instance.get_public_id(),
             'creation_time': self.object_instance.creation_time,
             'last_edit_time': self.object_instance.last_edit_time,
             'author_id': self.object_instance.author_id,
             'author_name': author_name,
+            'editor_id': self.object_instance.editor_id,
+            'editor_name': editor_name,
             'active': self.object_instance.active,
             'version': self.object_instance.version
         }


### PR DESCRIPTION
[NET-656](https://nethinks.atlassian.net/browse/NET-656) Dashboard: show latest editor in latest dashlet

Subtasks:
- [NET-806](https://nethinks.atlassian.net/browse/NET-806) cmdb object for last editor
- [NET-807](https://nethinks.atlassian.net/browse/NET-807) object render for last editor
- [NET-808](https://nethinks.atlassian.net/browse/NET-808) last editor in dashboard latest table
- [NET-809](https://nethinks.atlassian.net/browse/NET-809) user edit set in manager and rest routes
- [NET-810](https://nethinks.atlassian.net/browse/NET-810) ~~bulk user change editor~~


