### PR TITLE
[NET-1060] Crash after change type without cleanup

### DIFF
--- a/cmdb/framework/cmdb_render.py
+++ b/cmdb/framework/cmdb_render.py
@@ -264,11 +264,12 @@ class CmdbRender:
             elif type(section) is TypeReferenceSection and isinstance(section, TypeReferenceSection):
                 ref_field_name: str = f'{section.name}-field'
                 ref_field = self.type_instance.get_field(ref_field_name)
-                reference_id: int = self.object_instance.get_value(ref_field_name)
-                ref_field['value'] = reference_id
+
                 try:
+                    reference_id: int = self.object_instance.get_value(ref_field_name)
+                    ref_field['value'] = reference_id
                     reference_object: CmdbObject = self.object_manager.get_object(public_id=reference_id)
-                except ObjectManagerGetError:
+                except (ObjectManagerGetError, ValueError):
                     reference_object = None
                 ref_type: TypeModel = self.type_manager.get(section.reference.type_id)
                 ref_section = ref_type.get_section(section.reference.section_name)

--- a/cmdb/templates/template_data.py
+++ b/cmdb/templates/template_data.py
@@ -54,7 +54,7 @@ class ObjectTemplateData(AbstractTemplateData):
                     data["fields"][field_name] = self.__get_objectdata(cmdb_render_object.result(), iteration - 1)
                 elif field['type'] == 'ref-section-field':
                     data['fields'][field_name] = {'fields': {}}
-                    for section_ref_field in field['references']['fields']:
+                    for section_ref_field in field['references']['fields'] and field["value"]:
                         data['fields'][field_name]['fields'][section_ref_field['name']] = section_ref_field['value']
                 else:
                     data["fields"][field_name] = field["value"]


### PR DESCRIPTION
[[NET-1060]](https://nethinks.atlassian.net/browse/NET-1060) CmdbRenderer adapted. Newly added reference section fields are assigned an empty value.

[NET-1060]: https://nethinks.atlassian.net/browse/NET-1060