### PR TITLE
DAT-734-bump-jinja2

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==5.3.0
-sphinx_rtd_theme==1.1.1
-readthedocs-sphinx-search==0.1.1
-sphinxcontrib.httpdomain==1.8.0
+# sphinx==5.3.0
+# sphinx_rtd_theme==1.1.1
+# readthedocs-sphinx-search==0.1.1
+# sphinxcontrib.httpdomain==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-alabaster==0.7.13
+alabaster==0.7.16
 altgraph==0.17.4
-astroid==3.0.1
+astroid==3.1.0
 Authlib==1.2.1
-Babel==2.13.1
+Babel==2.14.0
 blinker==1.7.0
 Cerberus==1.3.5
-certifi==2023.7.22
+certifi==2024.2.2
 cffi==1.16.0
 click==8.1.7
 coverage==7.3.2
@@ -23,7 +23,7 @@ imagesize==1.4.1
 iniconfig==2.0.0
 isort==5.12.0
 itsdangerous==2.1.2
-Jinja2==3.1.2
+Jinja2==3.1.3
 lazy-object-proxy==1.9.0
 ldap3==2.9.1
 MarkupSafe==2.1.3
@@ -42,7 +42,7 @@ pyflakes==3.1.0
 Pygments==2.16.1
 pyinstaller==6.1.0
 pyinstaller-hooks-contrib==2023.10
-pylint==3.0.2
+pylint==3.1.0
 pymongo==4.6.0
 PyMySQL==1.1.0
 pyOpenSSL==23.3.0


### PR DESCRIPTION
Changes:
* Bumped several packages:
* Jinja2 to 3.1.3
* alabaster to 0.7.16
* astroid to 3.1.0
* pylint to 3.1.0
* Babel to 2.14.0
* certifi to 2024.2.2