### PR TITLE
DAT-2490-type-delete-followup

### DIFF
--- a/cmdb/interface/rest_api/routes/ci_explorer_routes/ci_explorer_routes.py
+++ b/cmdb/interface/rest_api/routes/ci_explorer_routes/ci_explorer_routes.py
@@ -634,7 +634,6 @@ def update_cmdb_ci_explorer_profile(public_id: int, data: dict, request_user: Cm
         if not to_update_explorer_profile:
             abort(404, f"The CiExplorer Profile with ID:{public_id} was not found!")
 
-
         ci_explorer_profile_manager.update_item(public_id, CmdbCiExplorerProfile.from_data(data))
 
         return UpdateSingleResponse(data).make_response()

--- a/cmdb/interface/rest_api/routes/framework_routes/cmdb_types/types_helper.py
+++ b/cmdb/interface/rest_api/routes/framework_routes/cmdb_types/types_helper.py
@@ -23,8 +23,17 @@ from flask import abort
 
 from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
 from cmdb.manager.query_builder import BuilderParameters
-from cmdb.manager import TypesManager, LocationsManager, ObjectsManager, ReportsManager
+from cmdb.manager import (
+    TypesManager,
+    LocationsManager,
+    ObjectsManager,
+    ReportsManager,
+    RelationsManager,
+    CiExplorerProfileManager,
+    ObjectGroupsManager,
+)
 
+from cmdb.models.object_group_model import ObjectGroupMode
 from cmdb.models.type_model.cmdb_type import CmdbType
 from cmdb.models.user_model.cmdb_user import CmdbUser
 from cmdb.models.object_model.cmdb_object import CmdbObject
@@ -197,3 +206,21 @@ def verify_type_deletable(
 
     if reports_count > 0:
         abort(403, "Delete not possible if Reports exist which are using this Type!")
+
+
+def type_deletion_followup(request_user: CmdbUser, public_id: int) -> None:
+    """TODO: document"""
+    relations_manager: RelationsManager = ManagerProvider.get_manager(ManagerType.RELATIONS, request_user)
+    object_groups_manager: ObjectGroupsManager = ManagerProvider.get_manager(ManagerType.OBJECT_GROUP, request_user)
+    ci_explorer_profile_manager: CiExplorerProfileManager = ManagerProvider.get_manager(
+        ManagerType.CI_EXPLORER_PROFILE,
+        request_user
+    )
+    # Delete this type_id from all relations parent and child ids
+    relations_manager.remove_type_from_relations(public_id)
+
+    # Delete this type_id from all CiExplorerProfiles
+    ci_explorer_profile_manager.remove_type_from_profiles(public_id)
+
+    # Delete the type from all dynamic groups
+    object_groups_manager.remove_ids_from_groups(public_id, ObjectGroupMode.DYNAMIC)

--- a/cmdb/interface/rest_api/routes/framework_routes/types_routes.py
+++ b/cmdb/interface/rest_api/routes/framework_routes/types_routes.py
@@ -26,18 +26,11 @@ from werkzeug.exceptions import HTTPException
 
 from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
 from cmdb.manager.query_builder import BuilderParameters
-from cmdb.manager import (
-    TypesManager,
-    ObjectsManager,
-    RelationsManager,
-    UsersManager,
-    ObjectGroupsManager,
-)
+from cmdb.manager import TypesManager, ObjectsManager, UsersManager
 
 from cmdb.models.user_model import CmdbUser
 from cmdb.models.type_model import CmdbType
 from cmdb.models.object_model import CmdbObject
-from cmdb.models.object_group_model import ObjectGroupMode
 from cmdb.framework.results import IterationResult
 from cmdb.interface.route_utils import insert_request_user, verify_api_access
 from cmdb.interface.rest_api.api_level_enum import ApiLevel
@@ -49,6 +42,7 @@ from cmdb.interface.rest_api.routes.framework_routes.cmdb_types.types_helper imp
     apply_type_changes_to_locations,
     apply_type_changes_to_mds,
     verify_type_deletable,
+    type_deletion_followup,
 )
 from cmdb.interface.blueprints import APIBlueprint
 from cmdb.interface.rest_api.responses.response_parameters import TypeIterationParameters
@@ -404,8 +398,6 @@ def delete_cmdb_type(public_id: int, request_user: CmdbUser):
     """
     try:
         types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
-        relations_manager: RelationsManager = ManagerProvider.get_manager(ManagerType.RELATIONS, request_user)
-        object_groups_manager: ObjectGroupsManager = ManagerProvider.get_manager(ManagerType.OBJECT_GROUP, request_user)
 
         to_delete_type: dict[str, Any] | None = types_manager.get_type(public_id)
 
@@ -415,12 +407,8 @@ def delete_cmdb_type(public_id: int, request_user: CmdbUser):
         # Delete the CmdbType
         types_manager.delete_type(public_id)
 
-        # Delete this type_id from all relations parent and child ids
-        relations_manager.remove_type_from_relations(public_id)
-
-        # Delete the type from all dynamic groups
-        object_groups_manager.remove_ids_from_groups(public_id, ObjectGroupMode.DYNAMIC)
-
+        # All the followup actions where the public_id need to be removed
+        type_deletion_followup(request_user, public_id)
         return DeleteSingleResponse(to_delete_type).make_response()
     except HTTPException as http_err:
         raise http_err

--- a/cmdb/interface/rest_api/routes/relation_routes/object_relation_routes.py
+++ b/cmdb/interface/rest_api/routes/relation_routes/object_relation_routes.py
@@ -44,6 +44,7 @@ from cmdb.interface.rest_api.responses import (
     GetSingleResponse,
     UpdateSingleResponse,
     DeleteSingleResponse,
+    DefaultResponse,
 )
 
 from cmdb.errors.manager.object_relations_manager import (
@@ -348,22 +349,22 @@ def delete_cmdb_object_relation(public_id: int, request_user: CmdbUser) -> Respo
 
         to_delete_object_relation = object_relations_manager.get_object_relation(public_id)
 
-        if to_delete_object_relation:
-            object_relations_manager.delete_object_relation(public_id)
+        if not to_delete_object_relation:
+            abort(404, f"The ObjectRelation with ID: {public_id} was not found!")
 
-            try:
-                object_relation_logs_manager.build_object_relation_log(
-                                                LogInteraction.DELETE,
-                                                request_user,
-                                                to_delete_object_relation,
-                                                None
-                                            )
-            except (ObjectRelationLogsManagerBuildError, ObjectRelationLogsManagerInsertError) as error:
-                LOGGER.error("[insert_cmdb_object_relation] Failed to create an ObjectRelationLog: %s",error,
-                                                                                                       exc_info=True)
+        object_relations_manager.delete_object_relation(public_id)
 
-            return DeleteSingleResponse(to_delete_object_relation).make_response()
-        abort(404, f"The ObjectRelation with ID: {public_id} was not found!")
+        try:
+            object_relation_logs_manager.build_object_relation_log(
+                                            LogInteraction.DELETE,
+                                            request_user,
+                                            to_delete_object_relation,
+                                            None
+                                        )
+        except Exception as error:
+            LOGGER.error("[delete_cmdb_object_relation] Failed to create ObjectRelationLog: %s",error, exc_info=True)
+
+        return DeleteSingleResponse(to_delete_object_relation).make_response()
     except HTTPException as http_err:
         raise http_err
     except ObjectRelationsManagerDeleteError as err:
@@ -375,3 +376,95 @@ def delete_cmdb_object_relation(public_id: int, request_user: CmdbUser) -> Respo
     except Exception as err:
         LOGGER.error("[delete_cmdb_object_relation] Exception: %s. Type: %s", err, type(err), exc_info=True)
         abort(500, f"An internal server error occured while deleting the ObjectRelation with ID:{public_id}!")
+
+
+@object_relations_blueprint.route('/delete/many', methods=['POST'])
+@insert_request_user
+@verify_api_access(required_api_level=ApiLevel.ADMIN)
+@object_relations_blueprint.protect(auth=True, right='base.framework.objectRelation.delete')
+def delete_many_object_relations(data: dict[str, Any], request_user: CmdbUser) -> Response:
+    """
+    HTTP `DELETE` route to delete multiple CmdbObjectRelations
+
+    Args:
+        request_user (CmdbUser): CmdbUser which is using this route
+
+    Returns:
+        DeleteSingleResponse: The deleted CmdbObjectRelation data
+    """
+    try:
+        target_ids: list[Any] | None = data.get('target_ids')
+
+        if not target_ids:
+            abort(400, "No public_ids provided of ObjectRelations which should be deleted!")
+
+        # Normalize the provided IDs
+        normalized_ids: list[int] = []
+
+        for tid in target_ids:
+            if isinstance(tid, int):
+                normalized_ids.append(tid)
+            elif isinstance(tid, str) and tid.isdigit():
+                normalized_ids.append(int(tid))
+            else:
+                abort(400, f"Invalid public_id for ObjectRelation deletion: {tid}")
+
+        object_relations_manager: ObjectRelationsManager = ManagerProvider.get_manager(
+            ManagerType.OBJECT_RELATIONS,
+            request_user
+        )
+        object_relation_logs_manager: ObjectRelationLogsManager = ManagerProvider.get_manager(
+            ManagerType.OBJECT_RELATION_LOGS,
+            request_user
+        )
+
+        # Retrieve all ObjectRelations which should be deleted
+        to_delete_object_relations: list[dict[str, Any]] = object_relations_manager.find(
+            criteria={'public_id': {"$in": normalized_ids}}
+        )
+
+        if not to_delete_object_relations:
+            abort(400, "No ObjectRelations exist with these IDs!")
+
+        # Delete all ObjectRelations with the provided target_ids
+        object_relations_manager.delete_many({'public_id': {"$in": normalized_ids}})
+
+        try:
+            # Prepare all the deletetion logs and create them
+            logs_to_create: list[dict[str, Any]] = []
+
+            for object_relation in to_delete_object_relations:
+                log_entry: dict[str, Any] = object_relation_logs_manager.format_object_relation_log_data(
+                    LogInteraction.DELETE,
+                    request_user,
+                    object_relation,
+                    None,
+                )
+
+                logs_to_create.append(log_entry)
+
+            if logs_to_create:
+                reserved_log_ids: list[int] = object_relation_logs_manager.reserve_public_ids(len(logs_to_create))
+
+                for log_doc, new_id in zip(logs_to_create, reserved_log_ids):
+                    log_doc["public_id"] = new_id
+
+                # Create all Logs
+                object_relation_logs_manager.insert_many(logs_to_create, skip_public=True)
+        except Exception as error:
+            LOGGER.error(
+                "[delete_many_object_relations] Failed to create deletion Logs: %s",error, exc_info=True
+            )
+
+        return DefaultResponse(True).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except ObjectRelationsManagerDeleteError as err:
+        LOGGER.error("[delete_many_object_relations] %s", err, exc_info=True)
+        abort(500, "Failed to delete the ObjectRelations!")
+    except ObjectRelationsManagerGetError as err:
+        LOGGER.error("[delete_many_object_relations] %s", err, exc_info=True)
+        abort(400, "Failed to retrieve the ObjectRelations from the database!")
+    except Exception as err:
+        LOGGER.error("[delete_many_object_relations] Exception: %s. Type: %s", err, type(err), exc_info=True)
+        abort(500, "An internal server error occured while deleting the ObjectRelations!")

--- a/cmdb/interface/rest_api/routes/relation_routes/relations_routes.py
+++ b/cmdb/interface/rest_api/routes/relation_routes/relations_routes.py
@@ -22,7 +22,7 @@ from flask import request, abort
 from werkzeug import Response
 from werkzeug.exceptions import HTTPException
 
-from cmdb.manager import RelationsManager, ObjectRelationsManager
+from cmdb.manager import RelationsManager, ObjectRelationsManager, CiExplorerProfileManager
 from cmdb.manager.query_builder import BuilderParameters
 from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
 
@@ -68,7 +68,7 @@ def insert_cmdb_relation(data: dict[str, Any], request_user: CmdbUser) -> Respon
 
     Args:
         data (CmdbRelation.SCHEMA): Data of the CmdbRelation which should be inserted
-        request_user (CmdbUser): User requesting this data
+        request_user (CmdbUser): CmdbUser which wants to create this CmdbRelation
 
     Returns:
         InsertSingleResponse: The new CmdbRelation and its public_id
@@ -247,8 +247,11 @@ def delete_cmdb_relation(public_id: int, request_user: CmdbUser) -> Response:
         DeleteSingleResponse: The deleted CmdbRelation data
     """
     try:
-        relations_manager: RelationsManager = ManagerProvider.get_manager(ManagerType.RELATIONS,
-                                                                           request_user)
+        relations_manager: RelationsManager = ManagerProvider.get_manager(ManagerType.RELATIONS, request_user)
+        ci_explorer_profile_manager: CiExplorerProfileManager = ManagerProvider.get_manager(
+            ManagerType.CI_EXPLORER_PROFILE,
+            request_user
+        )
 
         to_delete_relation = relations_manager.get_relation(public_id)
 
@@ -260,6 +263,9 @@ def delete_cmdb_relation(public_id: int, request_user: CmdbUser) -> Response:
             abort(403, f"The Relation with ID:{public_id} is currently in use and cannot be deleted!")
 
         relations_manager.delete_relation(public_id)
+
+        # Delete this relation from all CiExplorerProfiles
+        ci_explorer_profile_manager.remove_relation_from_profiles(public_id)
 
         return DeleteSingleResponse(raw=to_delete_relation).make_response()
     except HTTPException as http_err:

--- a/cmdb/manager/ci_explorer_profile_manager.py
+++ b/cmdb/manager/ci_explorer_profile_manager.py
@@ -37,5 +37,42 @@ class CiExplorerProfileManager(GenericManager):
 
     Extends: GenericManager
     """
-    def __init__(self, dbm: MongoDatabaseManager, database: str = None):
+    def __init__(self, dbm: MongoDatabaseManager, database: str = None) -> None:
         super().__init__(dbm, CmdbCiExplorerProfile, CI_EXPLORER_PROFILE_MANAGER_ERRORS, database)
+
+# --------------------------------------------------- CRUD - DELETE -------------------------------------------------- #
+
+    def remove_type_from_profiles(self, type_id: int) -> None:
+        """
+        Removes a type_id from all CiExplorerProfiles
+
+        Args:
+            type_id(int): public_id of the CmdbType which should be removed from all CiExplorerProfiles
+        """
+        criteria: dict[str, int] = {'types_filter': type_id}
+
+        update: dict[str, dict[str, int]] = {
+            '$pull': {
+                'types_filter': type_id
+            }
+        }
+
+        self.update_many(criteria=criteria, update=update, plain=True)
+
+
+    def remove_relation_from_profiles(self, relation_id: int) -> None:
+        """
+        Removes a relation_id from all CiExplorerProfiles
+
+        Args:
+            relation_id(int): public_id of the CmdbRelation which should be removed from all CiExplorerProfiles
+        """
+        criteria: dict[str, int] = {'relations_filter': relation_id}
+
+        update: dict[str, dict[str, int]] = {
+            '$pull': {
+                'relations_filter': relation_id
+            }
+        }
+
+        self.update_many(criteria=criteria, update=update, plain=True)

--- a/cmdb/manager/relations_manager.py
+++ b/cmdb/manager/relations_manager.py
@@ -169,16 +169,20 @@ class RelationsManager(BaseManager):
 
 
     def remove_type_from_relations(self, type_id: int) -> None:
-        """Removes a type_id from all relation parent/child lists."""
-
-        criteria = {
+        """
+        Removes a type_id from all relation parent/child lists
+        
+        Args:
+            type_id (int): public_id of the CmdbType which should be removed from all relations
+        """
+        criteria: dict[str, list[dict[str, int]]] = {
             '$or': [
                 {'parent_type_ids': type_id},
                 {'child_type_ids': type_id}
             ]
         }
 
-        update = {
+        update: dict[str, dict[str, int]] = {
             '$pull': {
                 'parent_type_ids': type_id,
                 'child_type_ids': type_id


### PR DESCRIPTION
Changes:
* When type is deleted, it is removed from ci explorer profiles
* When relation is deleted, it is removed from ci explorer profiles
* Added route to delete multiple object relations at once