### PR TITLE
DAT-2618-subnet-overview-limit

### DIFF
--- a/cmdb/framework/ipam/__init__.py
+++ b/cmdb/framework/ipam/__init__.py
@@ -14,6 +14,21 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-IPAM (IP Address Management) helpers and validators for SUPERNET, SUBNET, VLAN
-SpecialTypes and the dg-ipam-interface section template
+IP Address Management (IPAM) feature for DataGerry
+
+Provides the validators, overview builders, and shared CIDR helpers behind the IPAM
+SpecialTypes (SUPERNET, SUBNET, VLAN) and the dg-ipam-interface MDS section template.
+Modules:
+  - cidr: pure IPv4 helpers (parsing, containment, address-count policy)
+  - pagination: page/page_size clamping shared by the overview routes
+  - references: SpecialType id resolution
+  - subnet_validator / interface_validator / vlan_validator: structured per-row
+      validation invoked at save time and from the inline pre-validation REST routes
+  - range_change_guards: guards against subnet/supernet range edits that would orphan
+      child rows
+  - enforcement: cross-row enforcement helpers used by the validator orchestrators
+  - subnet_overview / supernet_overview: payload builders for the IPAM overview views
+
+Prefix-policy constants and field/section name enums are imported from
+cmdb.models.special_type_model.ipam_constants
 """

--- a/cmdb/framework/ipam/cidr.py
+++ b/cmdb/framework/ipam/cidr.py
@@ -14,66 +14,81 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-Pure IPv4 CIDR helpers used by the IPAM validators
+Pure IPv4 CIDR helpers used across the IPAM feature
 
-Every helper is stateless and free of DB access so it can be unit-tested in isolation
+Consumers include both the validators (subnet, supernet, interface, range-change guards,
+enforcement) and the overview builders (subnet overview, supernet overview). Every helper
+here is stateless and free of DB / Flask access so it can be unit-tested in isolation.
+Prefix-length policy constants (point-to-point threshold, network/broadcast reservation)
+live in cmdb.models.special_type_model.ipam_constants.IpamPrefixPolicy
 """
-from ipaddress import IPv4Address, IPv4Network, AddressValueError, NetmaskValueError
+from ipaddress import IPv4Address, IPv4Network
+
+from cmdb.models.special_type_model.ipam_constants import (
+    IpamAddressFormat,
+    IpamPrefixPolicy,
+)
 # -------------------------------------------------------------------------------------------------------------------- #
 
 
 def parse_cidr(value: str) -> IPv4Network | None:
     """
-    Parses a string as a strict IPv4 CIDR network
+    Parses a string as a strict IPv4 CIDR network in canonical 'A.B.C.D/N' notation
 
-    'Strict' means host bits must be zero (e.g. '10.0.0.0/24' is accepted, '10.0.0.5/24' is not)
+    Strict on two axes. Host bits must be zero (e.g. '10.0.0.0/24' is accepted, '10.0.0.5/24'
+    is not). The prefix length must be a plain integer (e.g. '10.0.0.0/24'); Python's
+    IPv4Network would additionally accept '/A.B.C.D' netmask or hostmask forms ('/255.255.255.0',
+    '/0.0.0.255') and a bare address with no slash (interpreting it as a /32 host route), but
+    those forms are rejected here so stored values are always canonical CIDR
 
     Args:
         value (str): The candidate CIDR string
 
     Returns:
-        IPv4Network | None: The parsed network, or None if the string is not a strict IPv4 CIDR
+        IPv4Network | None: The parsed network, or None if the input is not canonical CIDR
     """
     if not isinstance(value, str):
         return None
 
-    try:
-        return IPv4Network(value, strict=True)
-    except (AddressValueError, NetmaskValueError, ValueError):
+    if '/' not in value:
         return None
 
+    _, _, prefix_part = value.rpartition('/')
 
-def is_canonical_cidr(value: str) -> bool:
-    """
-    Reports whether a string is a syntactically valid, canonical IPv4 CIDR
+    if not prefix_part.isdigit():
+        return None
 
-    'Canonical' means host bits are zero (network address form)
-
-    Args:
-        value (str): The candidate CIDR string
-
-    Returns:
-        bool: True if the value parses as a strict IPv4 CIDR, False otherwise
-    """
-    return parse_cidr(value) is not None
+    try:
+        return IPv4Network(value, strict=True)
+    except ValueError:
+        return None
 
 
 def parse_ipv4(value: str) -> IPv4Address | None:
     """
-    Parses a string as an IPv4 address
+    Parses a string as an IPv4 address in dotted-quad notation
+
+    Only the canonical dotted-quad form ('A.B.C.D') is accepted. Python's IPv4Address would
+    additionally accept integer-formatted strings (e.g. '3232235521' as 192.168.1.1) and bare
+    integers, but those forms are rejected here so that stored interface values are always
+    human-readable. The function returns None for any input that is not a four-octet string
 
     Args:
         value (str): The candidate IPv4 address string
 
     Returns:
-        IPv4Address | None: The parsed address, or None if the string is not a valid IPv4 address
+        IPv4Address | None: The parsed address, or None if the input is not a valid
+            dotted-quad IPv4 address
     """
     if not isinstance(value, str):
         return None
 
+    if value.count('.') != IpamAddressFormat.DOTTED_QUAD_DOT_COUNT:
+        return None
+
     try:
         return IPv4Address(value)
-    except (AddressValueError, ValueError):
+    except ValueError:
         return None
 
 
@@ -166,33 +181,31 @@ def assignable_address_count(network: IPv4Network) -> int:
     Returns:
         int: Number of addresses an interface row may legitimately claim
     """
-    if network.prefixlen >= 31:
+    if network.prefixlen >= IpamPrefixPolicy.POINT_TO_POINT_THRESHOLD:
         return network.num_addresses
 
-    return network.num_addresses - 2
+    return network.num_addresses - IpamPrefixPolicy.RESERVED_ADDRESSES_PER_NETWORK
 
 
-def first_assignable_int(network: IPv4Network) -> int | None:
+def first_assignable_int(network: IPv4Network) -> int:
     """
     Returns the integer value of the first assignable address in a network
 
-    For /31 and /32 this is the network address itself (no exclusion). For /30 and shorter the
-    network address is skipped. Returns None only when the network has zero assignable
-    addresses, which currently cannot occur for any valid IPv4 prefix
+    For /31 and /32 networks this is the network address itself (no exclusion applies). For
+    /30 and shorter the network address is skipped and the first host follows at
+    IpamPrefixPolicy.FIRST_HOST_OFFSET. Every valid IPv4 prefix has at least one assignable
+    address under the current policy, so the function always returns an int
 
     Args:
         network (IPv4Network): The parsed network
 
     Returns:
-        int | None: Integer of the first assignable address, or None if none exist
+        int: Integer of the first assignable address
     """
-    if assignable_address_count(network) == 0:
-        return None
-
-    if network.prefixlen >= 31:
+    if network.prefixlen >= IpamPrefixPolicy.POINT_TO_POINT_THRESHOLD:
         return int(network.network_address)
 
-    return int(network.network_address) + 1
+    return int(network.network_address) + IpamPrefixPolicy.FIRST_HOST_OFFSET
 
 
 def is_network_or_broadcast(address: IPv4Address, network: IPv4Network) -> bool:
@@ -208,7 +221,7 @@ def is_network_or_broadcast(address: IPv4Address, network: IPv4Network) -> bool:
     Returns:
         bool: True if 'address' is the reserved network or broadcast address, False otherwise
     """
-    if network.prefixlen >= 31:
+    if network.prefixlen >= IpamPrefixPolicy.POINT_TO_POINT_THRESHOLD:
         return False
 
     return address == network.network_address or address == network.broadcast_address

--- a/cmdb/framework/ipam/subnet_overview.py
+++ b/cmdb/framework/ipam/subnet_overview.py
@@ -72,14 +72,10 @@ def _page_slice_ips(network: IPv4Network, page: int, page_size: int) -> list[str
         page_size (int): Number of IPs per page
 
     Returns:
-        list[str]: IP strings for the requested page; empty when the subnet has no assignable
-            addresses or the page is past the end
+        list[str]: IP strings for the requested page; empty when the page is past the end of
+            the assignable range
     """
-    first: int | None = first_assignable_int(network)
-
-    if first is None:
-        return []
-
+    first: int = first_assignable_int(network)
     total: int = assignable_address_count(network)
     start_offset: int = (page - 1) * page_size
 
@@ -175,26 +171,6 @@ def _extract_row_fields(row: dict[str, Any]) -> tuple[Any, Any, Any]:
     return subnet_ref, ip_value, mac_value
 
 
-def _empty_ip_distribution() -> dict[str, Any]:
-    """
-    Returns the zero-shaped 'ip_distribution' payload used when the subnet's CIDR is missing
-    or unparsable
-
-    The shape mirrors a populated distribution so the frontend can render a placeholder
-    without branching on a null sentinel
-
-    Returns:
-        dict[str, Any]: ranges_count / sectors_per_range / sector_size all 0 and an empty
-            'ranges' list
-    """
-    return {
-        'ranges_count': 0,
-        'sectors_per_range': 0,
-        'sector_size': 0,
-        'ranges': [],
-    }
-
-
 def _compute_grid_dimensions(total: int) -> tuple[int, int, int]:
     """
     Computes the grid layout (ranges, sectors per range, addresses per sector) for a subnet
@@ -272,7 +248,6 @@ def _bucket_used_counts(
 
 
 def _compose_sector(
-    sector_index: int,
     first_ip_int: int,
     sector_size: int,
     used_count: int,
@@ -281,22 +256,23 @@ def _compose_sector(
     Shapes one sector entry of the 'ip_distribution' grid
 
     The percentage is the per-cell saturation ('used_count / sector_size * 100'), rounded to
-    two decimals; this matches the frontend's heatmap colouring convention
+    two decimals; this matches the frontend's heatmap colouring convention. Position-implied
+    fields (sector index, sector size) are omitted: the consumer reads the index from the
+    sector's position in its parent range's 'sectors' array, and derives the size from
+    ip_end - ip_start + 1
 
     Args:
-        sector_index (int): 0-based index of the sector within its range
         first_ip_int (int): Integer of the first address the sector covers
-        sector_size (int): Number of addresses the sector covers
+        sector_size (int): Number of addresses the sector covers (used only for the percentage
+            denominator and to compute ip_end)
         used_count (int): Number of assigned IPs inside the sector
 
     Returns:
-        dict[str, Any]: Sector entry with index, ip_start, ip_end, size, used_count, percentage
+        dict[str, Any]: Sector entry with ip_start, ip_end, used_count, percentage
     """
     return {
-        'index': sector_index,
         'ip_start': str(IPv4Address(first_ip_int)),
         'ip_end': str(IPv4Address(first_ip_int + sector_size - 1)),
-        'size': sector_size,
         'used_count': used_count,
         'percentage': round((used_count / sector_size) * 100, 2),
     }
@@ -307,15 +283,20 @@ def _build_ip_distribution(
     assigned: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
     """
-    Builds the 'IP-Verteilung' grid payload for one subnet
+    Builds the 'IP-Verteilung' grid payload for one subnet, or an empty dict when no grid is rendered
 
-    Splits the full address space (network + broadcast included) into at most
-    IpamDistributionLimits.MAX_RANGES rows of at most MAX_SECTORS_PER_RANGE cells each, where
-    each cell aggregates the count of assigned IPs in its address window. Cells are sized by
-    'total // (ranges * sectors)' so every cell covers an equal slice of the subnet. For
-    subnets smaller than the cap the layout shrinks so no cell drops below 1 IP. The returned
-    structure is suitable for direct rendering by the frontend, which colours each cell by its
-    'percentage' field
+    The grid is only emitted at its full size (MAX_RANGES x MAX_SECTORS_PER_RANGE = 64 cells),
+    which corresponds to /26 and shorter prefixes. For /27 and narrower subnets the resulting
+    grid would have fewer cells; in that case (and when the CIDR is missing or unparsable) the
+    function returns an empty dict so the frontend can omit the visualisation entirely. When
+    rendered, every cell covers an equal slice of the subnet (network + broadcast included)
+    and carries the count of assigned IPs plus a per-cell saturation percentage that drives
+    the heatmap colouring
+
+    The returned structure is intentionally minimal: position-implied fields (range index,
+    sector index, sector size, top-level grid dimensions) are omitted because the grid
+    dimensions are fixed and the indexes follow array order. Range-level ip_start / ip_end are
+    kept because the frontend renders them as row labels next to each range
 
     Args:
         network (IPv4Network | None): The parsed subnet network, or None when the subnet's
@@ -325,16 +306,25 @@ def _build_ip_distribution(
             here
 
     Returns:
-        dict[str, Any]: ranges_count, sectors_per_range, sector_size, and a 'ranges' list with
-            one entry per range carrying index, ip_start, ip_end, and a nested 'sectors' list;
-            the zero-shaped payload from _empty_ip_distribution when network is None
+        dict[str, Any]: {'sector_size': N, 'ranges': [...]} when the subnet qualifies for the
+            full grid, where 'sector_size' is the number of addresses each cell covers (same
+            for every cell since the grid is uniform) and each range carries ip_start, ip_end,
+            and a nested 'sectors' list of cells with ip_start, ip_end, used_count,
+            percentage. Empty dict ({}) otherwise
     """
     if network is None:
-        return _empty_ip_distribution()
+        return {}
 
     total: int = total_address_count(network)
     ranges_count, sectors_per_range, sector_size = _compute_grid_dimensions(total)
     total_cells: int = ranges_count * sectors_per_range
+    max_grid_cells: int = (
+        IpamDistributionLimits.MAX_RANGES * IpamDistributionLimits.MAX_SECTORS_PER_RANGE
+    )
+
+    if total_cells < max_grid_cells:
+        return {}
+
     counts: list[int] = _bucket_used_counts(assigned, network, sector_size, total_cells)
 
     base_int: int = int(network.network_address)
@@ -350,22 +340,18 @@ def _build_ip_distribution(
             sector_first_int: int = range_first_int + sector_index * sector_size
             global_cell: int = range_index * sectors_per_range + sector_index
             sectors.append(_compose_sector(
-                sector_index,
                 sector_first_int,
                 sector_size,
                 counts[global_cell],
             ))
 
         ranges.append({
-            'index': range_index,
             'ip_start': str(IPv4Address(range_first_int)),
             'ip_end': str(IPv4Address(range_first_int + range_span - 1)),
             'sectors': sectors,
         })
 
     return {
-        'ranges_count': ranges_count,
-        'sectors_per_range': sectors_per_range,
         'sector_size': sector_size,
         'ranges': ranges,
     }
@@ -635,12 +621,15 @@ def build_subnet_overview(
             'ips': {page, page_size, total, rows: [...]},
             'type_distribution': [{public_id, label, ci_explorer_color, count, percentage},
             ...],
-            'ip_distribution': {ranges_count, sectors_per_range, sector_size, ranges: [...]}}
-            where 'type_distribution' covers the whole subnet (not just the current page) and
-            includes 'Unknown' (when present) and 'Free' buckets after the type buckets, and
-            'ip_distribution' is the IP-Verteilung heatmap grid covering the full address
-            space (network + broadcast included). 'ips.total' equals 'assignable_ips' so the
-            table paginates exactly the rows the validator would accept
+            'ip_distribution': {'sector_size': N, 'ranges': [...]} | {}} where
+            'type_distribution' covers the
+            whole subnet (not just the current page) and includes 'Unknown' (when present)
+            and 'Free' buckets after the type buckets, and 'ip_distribution' is the
+            IP-Verteilung heatmap grid covering the full address space (network + broadcast
+            included). The grid is emitted only at its full 4 x 16 size (/26 and shorter
+            prefixes); for /27 and narrower, or when the CIDR is unparsable, ip_distribution
+            is an empty dict. 'ips.total' equals 'assignable_ips' so the table paginates
+            exactly the rows the validator would accept
     """
     subnet_obj: dict[str, Any] = _load_subnet_object(objects_manager, types_manager, public_id)
 
@@ -666,7 +655,7 @@ def build_subnet_overview(
                 'rows': [],
             },
             'type_distribution': [],
-            'ip_distribution': _empty_ip_distribution(),
+            'ip_distribution': {},
         }
 
     total: int = total_address_count(network)

--- a/cmdb/models/special_type_model/ipam_constants.py
+++ b/cmdb/models/special_type_model/ipam_constants.py
@@ -114,6 +114,39 @@ class InterfaceField(str, Enum):
         return value in cls._value2member_map_
 
 
+class IpamPrefixPolicy:
+    """
+    Prefix-length thresholds that drive IPAM address-counting policy
+
+    POINT_TO_POINT_THRESHOLD is the prefix length at and above which the network and
+    broadcast addresses cease to be reserved: /31 uses both endpoints (RFC 3021
+    point-to-point) and /32 is treated as a single host route. Every helper that
+    distinguishes 'total' addresses from 'assignable' addresses consults this boundary
+
+    RESERVED_ADDRESSES_PER_NETWORK is the count of addresses removed from the host pool
+    for prefixes shorter than the point-to-point threshold (the network address plus the
+    broadcast address)
+
+    FIRST_HOST_OFFSET is the offset from the network address to the first assignable host
+    when the network/broadcast reservation applies
+    """
+    POINT_TO_POINT_THRESHOLD: int = 31
+    RESERVED_ADDRESSES_PER_NETWORK: int = 2
+    FIRST_HOST_OFFSET: int = 1
+
+
+class IpamAddressFormat:
+    """
+    Structural constants for IPv4 address notation accepted by the IPAM validators
+
+    DOTTED_QUAD_DOT_COUNT is the exact number of dots in canonical IPv4 dotted-quad form
+    (A.B.C.D). The IPAM parsers reject any string with a different dot count so that
+    integer-formatted strings such as '3232235521' (which Python's IPv4Address would silently
+    accept) cannot be stored as interface values
+    """
+    DOTTED_QUAD_DOT_COUNT: int = 3
+
+
 class IpamDistributionLimits:
     """
     Maximum dimensions of the subnet 'IP-Verteilung' grid

--- a/tests/functional/framework/test_functional_objects_bulk_change.py
+++ b/tests/functional/framework/test_functional_objects_bulk_change.py
@@ -14,7 +14,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-Bulk change objects - Tests
+Functional tests for bulk CmdbObject modification through the REST API
+
+These tests run against a real MongoDB instance and the full Flask test client; they exercise
+the /objects endpoint end-to-end (routing + auth + manager + persistence) rather than any
+single pure helper, so they belong under tests/functional, not tests/unit
 """
 from logging import Logger, getLogger
 import copy

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,23 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Integration tests for DataGerry
+
+This tier sits between the pure unit tests (no DB, no Flask) and the full functional tests
+(real REST API). Integration tests exercise the manager and framework layers against a real
+MongoDB instance but skip the Flask app and REST routing, so they run faster than functional
+tests while still covering real query behavior, persistence and cross-manager interactions
+"""

--- a/tests/integration/framework/__init__.py
+++ b/tests/integration/framework/__init__.py
@@ -1,0 +1,23 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Integration tests for the cmdb.framework package
+
+Tests in this folder run against a real MongoDB instance but skip the Flask app and REST
+routing, so they exercise framework-layer behavior (overview builders, validators, importers,
+exporters, rendering, search) and the managers they depend on without the cost of a full HTTP
+request cycle
+"""

--- a/tests/integration/management/__init__.py
+++ b/tests/integration/management/__init__.py
@@ -1,0 +1,22 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Integration tests for the cmdb.manager user-management modules
+
+Tests in this folder run against a real MongoDB instance but skip the Flask app, exercising
+the user, group, rights, and security managers directly to cover persistence and cross-manager
+behavior without going through the REST layer
+"""

--- a/tests/unit/framework/ipam/__init__.py
+++ b/tests/unit/framework/ipam/__init__.py
@@ -1,0 +1,21 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for the cmdb.framework.ipam package
+
+Each module here mirrors a single source file in cmdb/framework/ipam/. Tests are pure: no
+Mongo, no Flask, no fixtures beyond pytest.mark.parametrize tables
+"""

--- a/tests/unit/framework/ipam/test_cidr.py
+++ b/tests/unit/framework/ipam/test_cidr.py
@@ -1,0 +1,289 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for cmdb.framework.ipam.cidr
+
+Pure tests: no Mongo, no Flask, no fixtures. Each behavior is exercised through a
+pytest.mark.parametrize table so a new edge case is a single-line addition. Expected
+values are written as concrete literals rather than re-derived from the same constants
+the production code uses; tests act as specification-by-example so that an inadvertent
+policy change (e.g. flipping the point-to-point threshold) breaks the suite loudly
+"""
+from typing import Any
+from ipaddress import IPv4Address, IPv4Network
+
+import pytest
+
+from cmdb.framework.ipam.cidr import (
+    parse_cidr,
+    parse_ipv4,
+    is_strict_subnet,
+    is_network_or_broadcast,
+    assignable_address_count,
+    first_assignable_int,
+)
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                    parse_cidr                                                        #
+# -------------------------------------------------------------------------------------------------------------------- #
+@pytest.mark.parametrize('value, expected_cidr', [
+    ('10.0.0.0/24', '10.0.0.0/24'),
+    ('192.168.1.0/24', '192.168.1.0/24'),
+    ('0.0.0.0/0', '0.0.0.0/0'),
+    ('10.0.0.0/32', '10.0.0.0/32'),
+    ('10.0.0.0/31', '10.0.0.0/31'),
+    ('172.16.0.0/12', '172.16.0.0/12'),
+])
+def test_parse_cidr_accepts_canonical(value: str, expected_cidr: str) -> None:
+    """Canonical CIDRs (host bits all zero) parse to the matching IPv4Network"""
+    result: IPv4Network | None = parse_cidr(value)
+
+    assert result is not None
+    assert str(result) == expected_cidr
+
+
+@pytest.mark.parametrize('value', [
+    '10.0.0.5/24',
+    '192.168.1.7/16',
+    '10.0.0.128/24',
+])
+def test_parse_cidr_rejects_non_canonical(value: str) -> None:
+    """Non-canonical CIDRs (host bits set) are rejected by strict mode"""
+    assert parse_cidr(value) is None
+
+
+@pytest.mark.parametrize('value', [
+    'garbage',
+    '',
+    '10.0.0.0/',
+    '10.0.0.0/33',
+    '10.0.0.0/-1',
+    '10.0.0.0/abc',
+    '::1/128',
+    '10.0.0.0 ',
+    ' 10.0.0.0/24',
+])
+def test_parse_cidr_rejects_invalid_strings(value: str) -> None:
+    """Malformed CIDR strings return None instead of raising"""
+    assert parse_cidr(value) is None
+
+
+@pytest.mark.parametrize('value', [
+    '10.0.0.0',
+    '192.168.1.1',
+    '0.0.0.0',
+])
+def test_parse_cidr_rejects_bare_address(value: str) -> None:
+    """
+    A bare IPv4 address (no slash) is rejected — Python's IPv4Network would treat it as /32
+    but the canonical-CIDR contract requires an explicit prefix
+    """
+    assert parse_cidr(value) is None
+
+
+@pytest.mark.parametrize('value', [
+    '10.0.0.0/255.255.255.0',
+    '192.168.1.0/255.255.255.128',
+    '10.0.0.0/0.0.0.255',
+    '10.0.0.0/255.0.0.0',
+])
+def test_parse_cidr_rejects_dotted_mask_form(value: str) -> None:
+    """
+    Netmask ('/A.B.C.D') and hostmask ('/W.W.W.W') prefix forms are rejected even though
+    Python's IPv4Network accepts them; canonical CIDR uses '/N' integer form only
+    """
+    assert parse_cidr(value) is None
+
+
+@pytest.mark.parametrize('value', [
+    None,
+    123,
+    1.5,
+    b'10.0.0.0/24',
+    ['10.0.0.0/24'],
+    {'cidr': '10.0.0.0/24'},
+])
+def test_parse_cidr_rejects_non_string(value: Any) -> None:
+    """Non-string inputs are rejected by the isinstance guard, not by IPv4Network"""
+    assert parse_cidr(value) is None
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                    parse_ipv4                                                        #
+# -------------------------------------------------------------------------------------------------------------------- #
+@pytest.mark.parametrize('value, expected_address', [
+    ('10.0.0.1', '10.0.0.1'),
+    ('192.168.1.1', '192.168.1.1'),
+    ('0.0.0.0', '0.0.0.0'),
+    ('255.255.255.255', '255.255.255.255'),
+    ('172.16.0.42', '172.16.0.42'),
+])
+def test_parse_ipv4_accepts_dotted_quad(value: str, expected_address: str) -> None:
+    """Valid dotted-quad addresses parse to IPv4Address"""
+    result: IPv4Address | None = parse_ipv4(value)
+
+    assert result is not None
+    assert str(result) == expected_address
+
+
+@pytest.mark.parametrize('value', [
+    '3232235521',
+    '192.168.1',
+    '192.168.1.1.5',
+    '',
+    '10',
+    '....',
+])
+def test_parse_ipv4_rejects_wrong_dot_count(value: str) -> None:
+    """Anything other than exactly three dots is rejected before IPv4Address sees it"""
+    assert parse_ipv4(value) is None
+
+
+@pytest.mark.parametrize('value', [
+    '0xc0.0xa8.0x1.0x1',
+    '999.1.1.1',
+    'a.b.c.d',
+    '192.168.1.',
+    '.192.168.1',
+    '192.168..1',
+])
+def test_parse_ipv4_rejects_invalid_octets(value: str) -> None:
+    """Dotted-quad form with invalid octets is rejected by IPv4Address"""
+    assert parse_ipv4(value) is None
+
+
+@pytest.mark.parametrize('value', [
+    None,
+    123,
+    1.5,
+    b'192.168.1.1',
+    ['192.168.1.1'],
+    {'ip': '192.168.1.1'},
+])
+def test_parse_ipv4_rejects_non_string(value: Any) -> None:
+    """Non-string inputs are rejected by the isinstance guard"""
+    assert parse_ipv4(value) is None
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                 is_strict_subnet                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+@pytest.mark.parametrize('parent_cidr, child_cidr, expected', [
+    ('10.0.0.0/8', '10.0.0.0/24', True),
+    ('10.0.0.0/8', '10.255.0.0/16', True),
+    ('0.0.0.0/0', '10.0.0.0/8', True),
+    ('192.168.0.0/16', '192.168.1.0/24', True),
+
+    ('10.0.0.0/8', '10.0.0.0/8', False),
+    ('10.0.0.0/24', '10.0.0.0/24', False),
+    ('0.0.0.0/0', '0.0.0.0/0', False),
+
+    ('10.0.0.0/24', '192.168.1.0/24', False),
+    ('10.0.0.0/24', '10.0.1.0/24', False),
+    ('10.0.0.0/16', '192.168.0.0/16', False),
+
+    ('10.0.0.0/24', '10.0.0.0/16', False),
+])
+def test_is_strict_subnet(parent_cidr: str, child_cidr: str, expected: bool) -> None:
+    """Strict-subnet means contained AND not equal: parent == child must return False"""
+    parent: IPv4Network = IPv4Network(parent_cidr)
+    child: IPv4Network = IPv4Network(child_cidr)
+
+    assert is_strict_subnet(parent, child) is expected
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              is_network_or_broadcast                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+@pytest.mark.parametrize('address, cidr, expected', [
+    ('10.0.0.0', '10.0.0.0/24', True),
+    ('10.0.0.255', '10.0.0.0/24', True),
+    ('10.0.0.1', '10.0.0.0/24', False),
+    ('10.0.0.128', '10.0.0.0/24', False),
+    ('10.0.0.254', '10.0.0.0/24', False),
+
+    ('10.0.0.0', '10.0.0.0/16', True),
+    ('10.0.255.255', '10.0.0.0/16', True),
+    ('10.0.0.1', '10.0.0.0/16', False),
+    ('10.0.128.0', '10.0.0.0/16', False),
+
+    ('10.0.0.0', '10.0.0.0/30', True),
+    ('10.0.0.3', '10.0.0.0/30', True),
+    ('10.0.0.1', '10.0.0.0/30', False),
+    ('10.0.0.2', '10.0.0.0/30', False),
+
+    ('10.0.0.0', '10.0.0.0/31', False),
+    ('10.0.0.1', '10.0.0.0/31', False),
+
+    ('10.0.0.5', '10.0.0.5/32', False),
+    ('192.168.10.42', '192.168.10.42/32', False),
+])
+def test_is_network_or_broadcast(address: str, cidr: str, expected: bool) -> None:
+    """Network/broadcast reservation applies to /≤30 only; /31 and /32 carve out"""
+    assert is_network_or_broadcast(IPv4Address(address), IPv4Network(cidr)) is expected
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            assignable_address_count                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+@pytest.mark.parametrize('cidr, expected', [
+    ('10.0.0.5/32', 1),
+    ('192.168.10.42/32', 1),
+
+    ('10.0.0.0/31', 2),
+    ('192.168.1.0/31', 2),
+
+    ('10.0.0.0/30', 2),
+    ('10.0.0.0/29', 6),
+    ('10.0.0.0/28', 14),
+    ('10.0.0.0/27', 30),
+    ('10.0.0.0/26', 62),
+    ('10.0.0.0/25', 126),
+    ('10.0.0.0/24', 254),
+    ('10.0.0.0/23', 510),
+    ('10.0.0.0/16', 65534),
+    ('10.0.0.0/8', 16777214),
+    ('0.0.0.0/0', 4294967294),
+])
+def test_assignable_address_count(cidr: str, expected: int) -> None:
+    """Per-prefix assignable count: /32 -> 1, /31 -> 2, /<=30 -> num_addresses - 2"""
+    assert assignable_address_count(IPv4Network(cidr)) == expected
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              first_assignable_int                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+@pytest.mark.parametrize('cidr, expected_first_address', [
+    ('10.0.0.0/24', '10.0.0.1'),
+    ('10.0.0.0/30', '10.0.0.1'),
+    ('192.168.5.0/26', '192.168.5.1'),
+    ('172.16.0.0/16', '172.16.0.1'),
+    ('0.0.0.0/0', '0.0.0.1'),
+
+    ('10.0.0.0/31', '10.0.0.0'),
+    ('192.168.1.0/31', '192.168.1.0'),
+
+    ('10.0.0.5/32', '10.0.0.5'),
+    ('192.168.10.42/32', '192.168.10.42'),
+])
+def test_first_assignable_int(cidr: str, expected_first_address: str) -> None:
+    """First assignable: skip network for /<=30; include network address for /31 and /32"""
+    network: IPv4Network = IPv4Network(cidr)
+    expected_int: int = int(IPv4Address(expected_first_address))
+
+    assert first_assignable_int(network) == expected_int

--- a/tests/unit/management/__init__.py
+++ b/tests/unit/management/__init__.py
@@ -1,0 +1,22 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for the cmdb.manager user-management modules
+
+Pure tests for user, group, rights, and security helpers: no Mongo, no Flask, no fixtures
+beyond pytest.mark.parametrize tables. Each module here mirrors a single source file under
+cmdb/manager or cmdb/security
+"""


### PR DESCRIPTION
Changes:
* now only returns ip distribution for subnets with 64+ entries
* added unit tests