### PR TITLE
DAT-2647-invalid-routes

### DIFF
--- a/cmdb/framework/ipam/__init__.py
+++ b/cmdb/framework/ipam/__init__.py
@@ -28,6 +28,8 @@ Modules:
       child rows
   - enforcement: cross-row enforcement helpers used by the validator orchestrators
   - subnet_overview / supernet_overview: payload builders for the IPAM overview views
+  - supernet_membership: write-side mutations against the SUBNET <-> SUPERNET relation
+      (currently the batch 'unassign subnets from supernet' flow used by the overview)
 
 Prefix-policy constants and field/section name enums are imported from
 cmdb.models.special_type_model.ipam_constants

--- a/cmdb/framework/ipam/supernet_membership.py
+++ b/cmdb/framework/ipam/supernet_membership.py
@@ -1,0 +1,302 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Mutates the SUBNET <-> SUPERNET membership relation
+
+The frontend's supernet overview lets a user pick one or more rows and detach them from the
+supernet. Detach means clearing the SUBNET CmdbObject's 'dg-supernet-ref' field value to
+None; the subnet (and any of its CIDR-children that still reference the same supernet) stay
+in the database. CIDR-children are not auto-detached: a child that was nested under one of
+the selected subnets keeps its own dg-supernet-ref and simply surfaces as a new top-level
+row on the next overview load
+
+This module is intentionally read/write-split from supernet_overview.py: the overview module
+only shapes payloads, while every mutation against the membership relation lives here. The
+helpers are decomposed so each step (input coercion, supernet identity check, candidate
+membership query, batch field clear) is unit-testable in isolation. ``unassign_subnets_from_supernet``
+is the single orchestrator the route layer calls
+"""
+from typing import Any
+
+from flask import abort
+
+from cmdb.manager import ObjectsManager, TypesManager
+from cmdb.models.object_model import CmdbObjectKey, CmdbObjectFieldKey
+from cmdb.models.special_type_model.special_type_enum import SpecialType
+from cmdb.models.special_type_model.ipam_constants import SubnetField, IpamUnassignKey
+from cmdb.framework.ipam.references import resolve_special_type_id
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                  PURE HELPERS                                                        #
+# -------------------------------------------------------------------------------------------------------------------- #
+def normalize_subnet_id_list(raw: Any) -> list[int]:
+    """
+    Coerces the request payload's ``subnet_ids`` value into a deduplicated list of ints
+
+    The payload field is rejected with HTTP 400 when it is missing, not a list, empty, or
+    contains a non-integer (booleans are rejected even though Python treats them as ints,
+    so a stray ``true`` cannot silently target subnet id ``1``). Duplicates are removed
+    while preserving the order of the first occurrence so the response payload echoes the
+    list back in the caller's original order
+
+    Args:
+        raw (Any): The raw value read off the JSON body for the 'subnet_ids' key
+
+    Returns:
+        list[int]: The deduplicated, integer-typed subnet public_ids in input order
+    """
+    if not isinstance(raw, list) or not raw:
+        abort(400, f"'{IpamUnassignKey.SUBNET_IDS}' must be a non-empty list of integers!")
+
+    deduped: list[int] = []
+    seen: set[int] = set()
+
+    for entry in raw:
+        if isinstance(entry, bool) or not isinstance(entry, int):
+            abort(
+                400,
+                f"'{IpamUnassignKey.SUBNET_IDS}' contains a non-integer entry: {entry!r}",
+            )
+
+        if entry in seen:
+            continue
+
+        seen.add(entry)
+        deduped.append(entry)
+
+    return deduped
+
+
+def diff_missing_ids(requested: list[int], present_objs: list[dict[str, Any]]) -> list[int]:
+    """
+    Returns the requested public_ids that were not present in ``present_objs``
+
+    Used by the validate-all-or-nothing flow: ``present_objs`` is the result of querying the
+    DB for SUBNET CmdbObjects that are assigned to the supernet and whose public_id is in
+    ``requested``. Anything in ``requested`` that does not come back is either not a SUBNET,
+    does not exist, or is not currently assigned to the supernet. The order of ``requested``
+    is preserved in the returned list so error messages echo the caller's input order
+
+    Args:
+        requested (list[int]): The public_ids the caller asked to unassign
+        present_objs (list[dict[str, Any]]): SUBNET CmdbObject documents that came back from
+            the membership query
+
+    Returns:
+        list[int]: The subset of ``requested`` not represented in ``present_objs``,
+            in input order
+    """
+    present_ids: set[Any] = {obj.get(CmdbObjectKey.PUBLIC_ID) for obj in present_objs}
+
+    return [sid for sid in requested if sid not in present_ids]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   DATA LOADING                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def assert_supernet_exists(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    supernet_public_id: int,
+) -> None:
+    """
+    Aborts the request when the public_id does not resolve to a SUPERNET CmdbObject
+
+    Aborts HTTP 400 when no SUPERNET CmdbType is defined or when the public_id refers to a
+    CmdbObject of a different type; aborts HTTP 404 when no CmdbObject with the public_id
+    exists. Returns nothing on success - the caller does not need the supernet document
+    itself for the unassign flow
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        supernet_public_id (int): public_id the caller named as the supernet to detach from
+    """
+    supernet_type_id: int | None = resolve_special_type_id(types_manager, SpecialType.SUPERNET)
+
+    if supernet_type_id is None:
+        abort(400, "No SUPERNET CmdbType is defined; cannot unassign subnets!")
+
+    candidates: list[dict[str, Any]] = objects_manager.find_objects(
+        {CmdbObjectKey.PUBLIC_ID: supernet_public_id},
+        as_dict=True,
+    )
+
+    if not candidates:
+        abort(404, f"Supernet with public_id {supernet_public_id} was not found!")
+
+    if candidates[0].get(CmdbObjectKey.TYPE_ID) != supernet_type_id:
+        abort(400, f"Object with public_id {supernet_public_id} is not a SUPERNET!")
+
+
+def load_assigned_subnets(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    supernet_public_id: int,
+    subnet_ids: list[int],
+) -> list[dict[str, Any]]:
+    """
+    Returns SUBNET CmdbObject documents that are currently assigned to the supernet and
+    whose public_id is in ``subnet_ids``
+
+    A single Mongo query enforces three conditions at once: type is SUBNET, public_id is in
+    the requested set, and the dg-supernet-ref field value equals ``supernet_public_id``. Any
+    requested id that is not a SUBNET, does not exist, or is not assigned to this supernet is
+    simply absent from the result - callers use ``diff_missing_ids`` to surface them
+
+    Returns an empty list when no SUBNET CmdbType is defined yet so a virgin install cannot
+    falsely report unassignable ids; the caller's downstream diff will then report every
+    requested id as missing, which is still the correct outcome
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        supernet_public_id (int): public_id of the SUPERNET to check membership against
+        subnet_ids (list[int]): SUBNET public_ids the caller asked to unassign
+
+    Returns:
+        list[dict[str, Any]]: SUBNET CmdbObject documents matching all three conditions
+    """
+    subnet_type_id: int | None = resolve_special_type_id(types_manager, SpecialType.SUBNET)
+
+    if subnet_type_id is None:
+        return []
+
+    criteria: dict[str, Any] = {
+        CmdbObjectKey.PUBLIC_ID: {'$in': subnet_ids},
+        CmdbObjectKey.TYPE_ID: subnet_type_id,
+        CmdbObjectKey.FIELDS: {
+            '$elemMatch': {
+                CmdbObjectFieldKey.NAME: SubnetField.PARENT_SUPERNET,
+                CmdbObjectFieldKey.VALUE: supernet_public_id,
+            },
+        },
+    }
+
+    return objects_manager.find_objects(criteria, as_dict=True)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                      WRITES                                                          #
+# -------------------------------------------------------------------------------------------------------------------- #
+def clear_supernet_ref(
+    objects_manager: ObjectsManager,
+    subnet_ids: list[int],
+    supernet_public_id: int,
+) -> None:
+    """
+    Sets the dg-supernet-ref field value to None on every SUBNET CmdbObject whose public_id
+    is in ``subnet_ids`` AND that still references the supernet
+
+    Uses a single ``update_many_raw`` with an array filter so all updates land in one Mongo
+    write. The match conditions are deliberately strict on both the doc filter and the array
+    filter: both require ``dg-supernet-ref`` to be present with value equal to
+    ``supernet_public_id``. This closes the TOCTOU window between identity validation in
+    ``load_assigned_subnets`` and this write - if a concurrent writer reassigned one of the
+    requested SUBNETs to a different supernet in between, that SUBNET no longer matches and
+    its (new) assignment is left intact
+
+    Pre-condition: ``subnet_ids`` is non-empty - the orchestrator enforces this upstream via
+    ``normalize_subnet_id_list``, so passing an empty list is a programming error
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        subnet_ids (list[int]): SUBNET public_ids whose dg-supernet-ref should be cleared
+        supernet_public_id (int): public_id of the supernet the SUBNETs must currently
+            reference; SUBNETs no longer referencing this supernet are skipped
+    """
+    filter_query: dict[str, Any] = {
+        CmdbObjectKey.PUBLIC_ID: {'$in': subnet_ids},
+        CmdbObjectKey.FIELDS: {
+            '$elemMatch': {
+                CmdbObjectFieldKey.NAME: SubnetField.PARENT_SUPERNET,
+                CmdbObjectFieldKey.VALUE: supernet_public_id,
+            },
+        },
+    }
+    update: dict[str, Any] = {'$set': {'fields.$[f].value': None}}
+    array_filters: list[dict[str, Any]] = [{
+        'f.name': SubnetField.PARENT_SUPERNET,
+        'f.value': supernet_public_id,
+    }]
+
+    objects_manager.update_many_raw(
+        filter_query=filter_query,
+        update=update,
+        array_filters=array_filters,
+    )
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   ORCHESTRATOR                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def unassign_subnets_from_supernet(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    supernet_public_id: int,
+    raw_subnet_ids: Any,
+) -> dict[str, Any]:
+    """
+    Validates the request payload and detaches the named SUBNETs from the supernet
+
+    Pipeline:
+      1. Coerce ``raw_subnet_ids`` to a deduplicated list of ints (aborts 400 on bad shape)
+      2. Confirm ``supernet_public_id`` resolves to a SUPERNET CmdbObject (aborts 400/404)
+      3. Load the SUBNETs that are currently assigned to the supernet AND whose public_id
+         is in the requested list
+      4. If any requested id is not present in step 3's result, abort 400 with the offending
+         ids - the call is validate-all-or-nothing, so no write happens
+      5. Otherwise clear dg-supernet-ref on every requested SUBNET in one Mongo update_many
+
+    Children of a detached SUBNET are intentionally left attached: if a CIDR-child of one of
+    the requested SUBNETs also references this supernet, it stays assigned. Such children
+    simply surface as new top-level rows on the next overview load because their CIDR-parent
+    has dropped out of the tree
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        supernet_public_id (int): public_id of the SUPERNET to detach from
+        raw_subnet_ids (Any): The raw value read off the JSON body for the 'subnet_ids' key
+
+    Returns:
+        dict[str, Any]: {'subnet_ids': [int, ...], 'unassigned_count': int} where subnet_ids
+            echoes the deduplicated input order and unassigned_count is len(subnet_ids)
+    """
+    subnet_ids: list[int] = normalize_subnet_id_list(raw_subnet_ids)
+    assert_supernet_exists(objects_manager, types_manager, supernet_public_id)
+
+    assigned_objs: list[dict[str, Any]] = load_assigned_subnets(
+        objects_manager, types_manager, supernet_public_id, subnet_ids,
+    )
+
+    missing: list[int] = diff_missing_ids(subnet_ids, assigned_objs)
+
+    if missing:
+        abort(
+            400,
+            f"Cannot unassign subnets {missing} - they are not SUBNETs assigned to supernet"
+            f" {supernet_public_id}!",
+        )
+
+    clear_supernet_ref(objects_manager, subnet_ids, supernet_public_id)
+
+    return {
+        IpamUnassignKey.SUBNET_IDS: subnet_ids,
+        IpamUnassignKey.UNASSIGNED_COUNT: len(subnet_ids),
+    }

--- a/cmdb/framework/ipam/supernet_overview.py
+++ b/cmdb/framework/ipam/supernet_overview.py
@@ -340,6 +340,101 @@ def _annotate_has_children(
         row[IpamOverviewKey.HAS_CHILDREN] = bool(public_id is not None and children_index.get(public_id))
 
 
+def _annotate_is_valid(
+    rows: list[dict[str, Any]],
+    supernet_network: IPv4Network | None,
+) -> None:
+    """
+    Sets an 'is_valid' boolean on every row based on whether the row's CIDR sits strictly
+    inside the supernet's network
+
+    Rows are mutated in place. 'Valid' uses strict containment: the subnet's network must be
+    contained in the supernet network AND not be equal to it, so a subnet whose CIDR exactly
+    matches the supernet is reported as invalid. Rows with a missing or unparsable 'cidr'
+    field are always invalid (the field is the only authoritative signal of the subnet's
+    range). When the supernet network is None (its own CIDR is missing or unparsable) every
+    row is invalid - the FE then shows the orphan-all state until the supernet CIDR is fixed
+
+    Args:
+        rows (list[dict[str, Any]]): Rows produced by ``sort_and_link_subnets``
+        supernet_network (IPv4Network | None): Parsed CIDR of the supernet, or None when the
+            supernet's CIDR is missing or unparsable
+    """
+    for row in rows:
+        if supernet_network is None:
+            row[IpamOverviewKey.IS_VALID] = False
+            continue
+
+        cidr: Any = row.get(IpamOverviewKey.CIDR)
+        network: IPv4Network | None = parse_cidr(cidr) if isinstance(cidr, str) else None
+
+        if network is None:
+            row[IpamOverviewKey.IS_VALID] = False
+            continue
+
+        row[IpamOverviewKey.IS_VALID] = is_strict_subnet(supernet_network, network)
+
+
+def _count_invalid_rows(rows: list[dict[str, Any]]) -> int:
+    """
+    Returns how many rows carry 'is_valid' = False
+
+    Rows without an 'is_valid' key are counted as invalid: a caller that did not run
+    ``_annotate_is_valid`` against the same supernet network should not get a misleadingly
+    low count. The function does not mutate the input
+
+    Args:
+        rows (list[dict[str, Any]]): Rows that have been through ``_annotate_is_valid``
+
+    Returns:
+        int: Number of rows whose 'is_valid' is False (or absent)
+    """
+    return sum(1 for row in rows if not row.get(IpamOverviewKey.IS_VALID, False))
+
+
+def _select_invalid_rows(ordered_subnets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Returns every row whose 'is_valid' annotation is False, preserving input order
+
+    Used by the invalid-only orchestrator to surface the flat list of orphaned subnets after
+    ``_annotate_is_valid`` has run. A row missing the 'is_valid' key is treated as invalid
+    so that a caller that forgot to run the annotator does not get a misleadingly empty list
+
+    Args:
+        ordered_subnets (list[dict[str, Any]]): Rows that have been through ``_annotate_is_valid``
+
+    Returns:
+        list[dict[str, Any]]: The subset of ``ordered_subnets`` carrying is_valid=False,
+            in their original relative order (ascending CIDR, with unsortable rows trailing)
+    """
+    return [row for row in ordered_subnets if not row.get(IpamOverviewKey.IS_VALID, False)]
+
+
+def _active_search(search: str) -> str | None:
+    """
+    Normalizes a raw search query and reports whether it is active
+
+    A query is active when, after stripping surrounding whitespace, it carries at least
+    IpamSearch.MIN_QUERY_LENGTH characters. Active queries are returned as the stripped
+    string callers should pass to ``_filter_rows_by_network_substring``; inactive queries
+    (None / empty / whitespace / too short) return None so callers can keep the "no filter"
+    branch as a simple ``is None`` check. The IpamSearch.MAX_QUERY_LENGTH truncation is the
+    route's responsibility - this helper does not re-clip
+
+    Args:
+        search (str): Raw search query as received by the caller
+
+    Returns:
+        str | None: The stripped query when active, None otherwise
+    """
+    needle: str = (search or '').strip()
+
+    if len(needle) >= IpamSearch.MIN_QUERY_LENGTH:
+        return needle
+
+    return None
+
+
 def _select_listed_rows(
     ordered_subnets: list[dict[str, Any]],
     search: str,
@@ -347,9 +442,8 @@ def _select_listed_rows(
     """
     Picks the rows to expose in the supernet overview's 'subnets' block
 
-    Encapsulates the search-vs-tree branch and the search-input normalization. The supplied
-    ``search`` value is stripped of surrounding whitespace; if at least IpamSearch.MIN_QUERY_LENGTH
-    characters remain the rows are filtered to every subnet whose 'network' property contains
+    Encapsulates the search-vs-tree branch. When the search query is active (see
+    ``_active_search``) the rows are filtered to every subnet whose 'network' property contains
     the query as a case-insensitive substring (regardless of nesting depth). Otherwise the
     function falls back to the top-level tree view, returning only rows whose 'parent_id' is
     None - the same set the overview surfaces when no search is active
@@ -363,12 +457,43 @@ def _select_listed_rows(
     Returns:
         list[dict[str, Any]]: Rows to list in the overview, preserving the input row order
     """
-    needle: str = (search or '').strip()
+    needle: str | None = _active_search(search)
 
-    if len(needle) >= IpamSearch.MIN_QUERY_LENGTH:
+    if needle is not None:
         return _filter_rows_by_network_substring(ordered_subnets, needle)
 
     return [row for row in ordered_subnets if row.get(IpamOverviewKey.PARENT_ID) is None]
+
+
+def _select_invalid_listed_rows(
+    ordered_subnets: list[dict[str, Any]],
+    search: str,
+) -> list[dict[str, Any]]:
+    """
+    Picks the rows to expose in the invalid-subnets-only overview's 'subnets' block
+
+    Parallel to ``_select_listed_rows`` but scoped to the invalid subset: always restricts to
+    rows whose 'is_valid' annotation is False, then applies the shared search activation rule
+    via ``_active_search``. With an active search the result is further filtered to entries
+    whose 'network' (cidr) property contains the query as a case-insensitive substring;
+    otherwise every invalid row is returned. The tree shape is intentionally dropped: this
+    view is a flat list at every depth
+
+    Args:
+        ordered_subnets (list[dict[str, Any]]): Rows that have been through ``_annotate_is_valid``
+        search (str): Raw search query as received by the caller; may be empty, whitespace or
+            shorter than the minimum query length
+
+    Returns:
+        list[dict[str, Any]]: Invalid rows to list, preserving the input row order
+    """
+    invalid: list[dict[str, Any]] = _select_invalid_rows(ordered_subnets)
+    needle: str | None = _active_search(search)
+
+    if needle is not None:
+        return _filter_rows_by_network_substring(invalid, needle)
+
+    return invalid
 
 
 def _paginate_rows(
@@ -737,6 +862,48 @@ def _summarize_supernet(
     return compute_supernet_summary(supernet_network, total_used, len(ordered_subnets))
 
 
+def _prepare_supernet_view(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    public_id: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any], int]:
+    """
+    Loads the supernet and builds the fully-annotated subnet row list shared by the
+    paginated-view orchestrators
+
+    Encapsulates the pipeline that ``build_supernet_overview`` and
+    ``build_invalid_subnet_overview`` both need before they diverge into their own row-
+    selection logic: load the supernet (aborts 400/404 on failure), parse its CIDR, build
+    the linked subnet rows, annotate 'has_children' and 'is_valid', compute the KPI summary,
+    and count the invalid rows. Returning the supernet doc, the annotated row list, the
+    summary and the invalid count lets each consumer assemble its response envelope with one
+    line of work and keeps the O(n) invalid-count scan in exactly one place
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        public_id (int): public_id of the supernet to prepare
+
+    Returns:
+        tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any], int]:
+            (supernet CmdbObject document, annotated rows in CIDR order, KPI summary dict,
+            total number of invalid rows across the full row set)
+    """
+    supernet_obj: dict[str, Any] = _load_supernet_object(objects_manager, types_manager, public_id)
+    supernet_network: IPv4Network | None = _parse_supernet_cidr(supernet_obj)
+
+    ordered_subnets: list[dict[str, Any]] = _build_linked_subnet_rows(
+        objects_manager, types_manager, public_id,
+    )
+    _annotate_has_children(ordered_subnets, _index_children_by_parent(ordered_subnets))
+    _annotate_is_valid(ordered_subnets, supernet_network)
+
+    summary: dict[str, Any] = _summarize_supernet(ordered_subnets, supernet_network)
+    invalid_count: int = _count_invalid_rows(ordered_subnets)
+
+    return supernet_obj, ordered_subnets, summary, invalid_count
+
+
 def build_supernet_overview(
     objects_manager: ObjectsManager,
     types_manager: TypesManager,
@@ -753,7 +920,14 @@ def build_supernet_overview(
     The 'subnets' block lists rows paginated with the same page / page_size semantics used by
     the subnet overview. Each returned row carries 'has_children: bool' so the frontend can
     render an expand caret without a probe request; the direct children themselves are fetched
-    via ``build_supernet_subnet_children``
+    via ``build_supernet_subnet_children``. Each row also carries 'is_valid: bool' - true when
+    the subnet's CIDR sits strictly inside the supernet's CIDR, false when the subnet's range
+    no longer fits (e.g. the supernet's CIDR was edited and orphaned the subnet) or when the
+    subnet / supernet CIDR is missing or unparsable
+
+    The top-level 'invalid_count' is the total number of invalid subnets under the supernet
+    regardless of pagination, search or nesting depth; the FE uses it to render a banner that
+    deep-links to the dedicated invalid-only view (``build_invalid_subnet_overview``)
 
     When ``search`` is empty / whitespace, the 'subnets' block lists only top-level subnets -
     those whose CIDR is not strictly contained by any sibling. When ``search`` is non-empty,
@@ -779,16 +953,12 @@ def build_supernet_overview(
 
     Returns:
         dict[str, Any]: {'supernet': {public_id, ...summary over all subnets...},
-            'subnets': {page, page_size, total, rows: [...subnet rows with has_children]}}
+            'subnets': {page, page_size, total, rows: [...subnet rows with has_children, is_valid]},
+            'invalid_count': total invalid subnets under the supernet}
     """
-    supernet_obj: dict[str, Any] = _load_supernet_object(objects_manager, types_manager, public_id)
-
-    ordered_subnets: list[dict[str, Any]] = _build_linked_subnet_rows(
+    supernet_obj, ordered_subnets, summary, invalid_count = _prepare_supernet_view(
         objects_manager, types_manager, public_id,
     )
-    _annotate_has_children(ordered_subnets, _index_children_by_parent(ordered_subnets))
-
-    summary: dict[str, Any] = _summarize_supernet(ordered_subnets, _parse_supernet_cidr(supernet_obj))
 
     listed_rows: list[dict[str, Any]] = _select_listed_rows(ordered_subnets, search)
     safe_page, safe_size, page_rows = _paginate_rows(listed_rows, page, page_size)
@@ -804,6 +974,7 @@ def build_supernet_overview(
             IpamOverviewKey.TOTAL: len(listed_rows),
             IpamOverviewKey.ROWS: page_rows,
         },
+        IpamOverviewKey.INVALID_COUNT: invalid_count,
     }
 
 
@@ -818,8 +989,10 @@ def build_supernet_subnet_children(
 
     Returns every subnet whose closest CIDR-enclosing sibling under the same supernet is
     ``subnet_public_id`` - i.e. one level of nesting only. Children are returned in ascending
-    CIDR order (inherited from ``sort_and_link_subnets``). Each child row also carries
+    CIDR order (inherited from ``sort_and_link_subnets``). Each child row carries
     ``has_children`` so the frontend can render nested expand carets without follow-up probes
+    and ``is_valid`` so the FE can flag children that fall outside the supernet's current CIDR
+    (e.g. after a range edit that orphaned them)
 
     Aborts with HTTP 404 when the supernet does not exist, HTTP 400 when the supernet id
     refers to a non-supernet CmdbObject, when no SUPERNET / SUBNET CmdbType is defined, or
@@ -835,7 +1008,9 @@ def build_supernet_subnet_children(
     Returns:
         dict[str, Any]: {'parent': {'public_id': subnet_public_id}, 'rows': [child_row, ...]}
     """
-    _load_supernet_object(objects_manager, types_manager, supernet_public_id)
+    supernet_obj: dict[str, Any] = _load_supernet_object(
+        objects_manager, types_manager, supernet_public_id,
+    )
 
     ordered_subnets: list[dict[str, Any]] = _build_linked_subnet_rows(
         objects_manager, types_manager, supernet_public_id,
@@ -854,10 +1029,82 @@ def build_supernet_subnet_children(
 
     children_index: dict[Any, list[dict[str, Any]]] = _index_children_by_parent(ordered_subnets)
     _annotate_has_children(ordered_subnets, children_index)
+    _annotate_is_valid(ordered_subnets, _parse_supernet_cidr(supernet_obj))
 
     children: list[dict[str, Any]] = children_index.get(subnet_public_id, [])
 
     return {
         IpamOverviewKey.PARENT: {CmdbObjectKey.PUBLIC_ID: subnet_public_id},
         IpamOverviewKey.ROWS: children,
+    }
+
+
+def build_invalid_subnet_overview(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    public_id: int,
+    page: int = 1,
+    page_size: int = IpamPagination.DEFAULT_PAGE_SIZE,
+    search: str = '',
+) -> dict[str, Any]:
+    """
+    Builds the paginated invalid-subnets-only overview payload
+
+    Same envelope as ``build_supernet_overview`` (``supernet`` summary block, ``subnets`` page
+    block, top-level ``invalid_count``), with one intentional difference in the ``subnets``
+    block: the tree shape is dropped. The block is a flat list of every subnet under the
+    supernet whose 'is_valid' annotation is False, regardless of nesting depth. Each row still
+    carries 'parent_id' / 'has_children' / 'is_valid' / 'vlans' so the FE can render the same
+    row template it uses for the main overview
+
+    Search semantics mirror ``build_supernet_overview``: when ``search`` is empty / whitespace
+    or shorter than IpamSearch.MIN_QUERY_LENGTH after stripping, every invalid row is returned;
+    otherwise the invalid set is filtered to entries whose 'network' property contains
+    ``search`` as a case-insensitive substring. ``subnets.total`` reflects the search-filtered
+    count, while the top-level ``invalid_count`` and the 'supernet' KPI strip are computed over
+    every subnet under the supernet (not just the page or the search match), so those metrics
+    stay stable as the user paginates or filters
+
+    Rows are ordered ascending by CIDR (inherited from ``sort_and_link_subnets``); rows with
+    unparsable CIDR are also invalid and trail the sorted block
+
+    Aborts with HTTP 404 when the supernet does not exist, HTTP 400 when the public_id refers
+    to a non-supernet CmdbObject or no SUPERNET CmdbType is defined
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        public_id (int): public_id of the supernet whose invalid subnets are listed
+        page (int): 1-based page number for the subnet list (clamped into the valid range)
+        page_size (int): Page size for the subnet list (clamped to
+            [IpamPagination.MIN_PAGE_SIZE, IpamPagination.MAX_PAGE_SIZE])
+        search (str): Optional case-insensitive substring filter against each invalid subnet's
+            'network' property; empty / whitespace and queries shorter than
+            IpamSearch.MIN_QUERY_LENGTH after stripping are ignored and restore the unfiltered
+            invalid list
+
+    Returns:
+        dict[str, Any]: {'supernet': {public_id, ...summary over all subnets...},
+            'subnets': {page, page_size, total, rows: [...invalid rows in CIDR order]},
+            'invalid_count': total invalid subnets under the supernet}
+    """
+    supernet_obj, ordered_subnets, summary, invalid_count = _prepare_supernet_view(
+        objects_manager, types_manager, public_id,
+    )
+
+    listed_rows: list[dict[str, Any]] = _select_invalid_listed_rows(ordered_subnets, search)
+    safe_page, safe_size, page_rows = _paginate_rows(listed_rows, page, page_size)
+
+    return {
+        IpamOverviewKey.SUPERNET: {
+            CmdbObjectKey.PUBLIC_ID: supernet_obj.get(CmdbObjectKey.PUBLIC_ID),
+            **summary,
+        },
+        IpamOverviewKey.SUBNETS: {
+            IpamOverviewKey.PAGE: safe_page,
+            IpamOverviewKey.PAGE_SIZE: safe_size,
+            IpamOverviewKey.TOTAL: len(listed_rows),
+            IpamOverviewKey.ROWS: page_rows,
+        },
+        IpamOverviewKey.INVALID_COUNT: invalid_count,
     }

--- a/cmdb/interface/rest_api/routes/ipam_routes/ipam_supernet_routes.py
+++ b/cmdb/interface/rest_api/routes/ipam_routes/ipam_supernet_routes.py
@@ -16,8 +16,11 @@
 """
 REST routes for SUPERNET-centric IPAM views
 
-Exposes the paginated top-level supernet overview that powers the 'Supernet Übersicht' view
-and a per-subnet 'direct children' endpoint used to lazily expand a subnet row in that view
+Exposes the paginated top-level supernet overview that powers the 'Supernet Übersicht' view,
+a per-subnet 'direct children' endpoint used to lazily expand a subnet row in that view, the
+paginated invalid-subnets-only overview that lists subnets whose CIDR no longer fits inside
+the supernet, and the batch 'unassign subnets' endpoint that clears dg-supernet-ref on
+multiple SUBNETs at once
 """
 from logging import Logger, getLogger
 from typing import Any
@@ -30,11 +33,18 @@ from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
 from cmdb.manager import ObjectsManager, TypesManager
 
 from cmdb.models.user_model import CmdbUser
-from cmdb.models.special_type_model.ipam_constants import IpamPagination, IpamSearch, IpamOverviewKey
+from cmdb.models.special_type_model.ipam_constants import (
+    IpamPagination,
+    IpamSearch,
+    IpamOverviewKey,
+    IpamUnassignKey,
+)
 from cmdb.framework.ipam.supernet_overview import (
+    build_invalid_subnet_overview,
     build_supernet_overview,
     build_supernet_subnet_children,
 )
+from cmdb.framework.ipam.supernet_membership import unassign_subnets_from_supernet
 from cmdb.interface.route_utils import insert_request_user, verify_api_access
 from cmdb.interface.rest_api.api_level_enum import ApiLevel
 from cmdb.interface.blueprints import APIBlueprint
@@ -161,4 +171,122 @@ def get_supernet_subnet_children(public_id: int, subnet_id: int, request_user: C
             500,
             f"An internal server error occured while loading children of Subnet {subnet_id}"
             f" under Supernet {public_id}!",
+        )
+
+
+@ipam_supernet_blueprint.route('/overview/<int:public_id>/subnets/invalid', methods=['GET'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def get_invalid_subnet_overview(public_id: int, request_user: CmdbUser) -> Response:
+    """
+    HTTP `GET` route returning the paginated invalid-subnets-only overview payload
+
+    Same envelope as ``get_supernet_overview`` ('supernet' summary block, 'subnets' page block,
+    top-level 'invalid_count'), but 'subnets.rows' is a flat list (no tree shape) of every
+    subnet under the supernet whose CIDR does NOT sit strictly inside the supernet's current
+    CIDR. Each row carries the same shape as the main overview rows so the FE can reuse its
+    row template; invalid rows ordered by ascending CIDR with unparsable-CIDR rows trailing
+
+    Query params:
+        page (int, default=1): 1-based page number; clamped into the valid range server-side
+        page_size (int, default=50): page size; clamped into [1, 500] server-side
+        search (str, optional): case-insensitive substring filter against each invalid subnet's
+            'network' property; empty / whitespace and queries shorter than
+            IpamSearch.MIN_QUERY_LENGTH are ignored, queries longer than
+            IpamSearch.MAX_QUERY_LENGTH are truncated at the route boundary
+
+    Args:
+        public_id (int): public_id of the SUPERNET CmdbObject whose invalid subnets are listed
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: {'supernet': {...summary, public_id}, 'subnets': {page, page_size, total,
+            rows: [...invalid subnet rows]}, 'invalid_count': int}
+    """
+    try:
+        page: int = request.args.get(IpamOverviewKey.PAGE, default=1, type=int) or 1
+        page_size: int = (
+            request.args.get(IpamOverviewKey.PAGE_SIZE, default=IpamPagination.DEFAULT_PAGE_SIZE, type=int)
+            or IpamPagination.DEFAULT_PAGE_SIZE
+        )
+        raw_search: str = request.args.get(IpamOverviewKey.SEARCH, default='', type=str) or ''
+        search: str = raw_search[:IpamSearch.MAX_QUERY_LENGTH]
+
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        overview: dict[str, Any] = build_invalid_subnet_overview(
+            objects_manager,
+            types_manager,
+            public_id,
+            page=page,
+            page_size=page_size,
+            search=search,
+        )
+
+        return DefaultResponse(overview).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[get_invalid_subnet_overview] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(
+            500,
+            f"An internal server error occured while building the invalid-subnets overview"
+            f" for Supernet with ID: {public_id}!",
+        )
+
+
+@ipam_supernet_blueprint.route('/overview/<int:public_id>/subnets/unassign', methods=['POST'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def unassign_subnets_route(public_id: int, request_user: CmdbUser) -> Response:
+    """
+    HTTP `POST` route that detaches one or more SUBNETs from the supernet
+
+    Clears the 'dg-supernet-ref' field value to None on every SUBNET CmdbObject named in the
+    request body, validate-all-or-nothing: if any id is not a SUBNET currently assigned to
+    the supernet, the route aborts 400 with the offending ids and no write happens. CIDR-
+    children of detached SUBNETs are left attached - they keep their own dg-supernet-ref and
+    will surface as new top-level rows on the next overview load
+
+    Body:
+        subnet_ids (list[int]): public_ids of SUBNETs to detach; must be a non-empty list,
+            duplicates are silently collapsed while preserving input order
+
+    Args:
+        public_id (int): public_id of the SUPERNET CmdbObject the subnets are detached from
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: {'subnet_ids': [int, ...], 'unassigned_count': int}; subnet_ids echoes the
+            deduplicated request order
+    """
+    try:
+        payload: dict[str, Any] = request.get_json(silent=True) or {}
+
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        result: dict[str, Any] = unassign_subnets_from_supernet(
+            objects_manager,
+            types_manager,
+            public_id,
+            payload.get(IpamUnassignKey.SUBNET_IDS),
+        )
+
+        return DefaultResponse(result).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[unassign_subnets_route] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(
+            500,
+            f"An internal server error occured while unassigning subnets from Supernet"
+            f" with ID: {public_id}!",
         )

--- a/cmdb/models/special_type_model/ipam_constants.py
+++ b/cmdb/models/special_type_model/ipam_constants.py
@@ -218,11 +218,13 @@ class IpamOverviewKey(BaseStrEnum):
     FREE_PERCENT = 'free_percent'
     UTILIZATION_PERCENT = 'utilization_percent'
     SUBNET_COUNT = 'subnet_count'
+    INVALID_COUNT = 'invalid_count'
 
     # Per-subnet row fields specific to the supernet row table
     USAGE_PERCENT = 'usage_percent'
     PARENT_ID = 'parent_id'
     HAS_CHILDREN = 'has_children'
+    IS_VALID = 'is_valid'
     VLANS = 'vlans'
     NAME = 'name'
 
@@ -265,6 +267,19 @@ class IpamRowStatus(BaseStrEnum):
     """
     ASSIGNED = 'assigned'
     FREE = 'free'
+
+
+class IpamUnassignKey(BaseStrEnum):
+    """
+    Request and response payload keys for the supernet 'unassign subnets' route
+
+    SUBNET_IDS is the request-body field carrying the list of subnet public_ids the caller
+    asks to detach from the supernet. UNASSIGNED_COUNT is the response field echoing how
+    many subnets the route actually cleared. Both are scoped to the unassign route alone -
+    keys shared with the read-side overview payload live in IpamOverviewKey instead
+    """
+    SUBNET_IDS = 'subnet_ids'
+    UNASSIGNED_COUNT = 'unassigned_count'
 
 
 class IpamBucketLabel(BaseStrEnum):

--- a/tests/unit/framework/ipam/test_supernet_membership.py
+++ b/tests/unit/framework/ipam/test_supernet_membership.py
@@ -1,0 +1,430 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for cmdb.framework.ipam.supernet_membership
+
+Covers the pure helpers (normalize_subnet_id_list, diff_missing_ids), the DB-touching
+single-step helpers (assert_supernet_exists, load_assigned_subnets, clear_supernet_ref),
+and the unassign_subnets_from_supernet orchestrator. Mongo query shapes are pinned via
+assert_called_once_with so any future relaxation fails loudly - the clear write filter is
+checked in particular detail because it carries the TOCTOU-safety guarantee. Flask aborts
+are exercised via pytest.raises(HTTPException) without needing a request context. The
+orchestrator's helpers are patched at the module path so each orchestrator test verifies
+orchestration in isolation; each helper has its own dedicated tests in this file
+"""
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from werkzeug.exceptions import HTTPException, NotFound
+
+from cmdb.models.object_model import CmdbObjectKey, CmdbObjectFieldKey
+from cmdb.models.special_type_model.special_type_enum import SpecialType
+from cmdb.models.special_type_model.ipam_constants import SubnetField, IpamUnassignKey
+from cmdb.models.type_model.type_schema_key_enum import TypeSchemaKey
+from cmdb.framework.ipam.supernet_membership import (
+    assert_supernet_exists,
+    clear_supernet_ref,
+    diff_missing_ids,
+    load_assigned_subnets,
+    normalize_subnet_id_list,
+    unassign_subnets_from_supernet,
+)
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+SUPERNET_TYPE_ID: int = 10
+SUBNET_TYPE_ID: int = 11
+SUPERNET_OBJECT_ID: int = 100
+SUBNET_OBJECT_ID_A: int = 201
+SUBNET_OBJECT_ID_B: int = 202
+SUBNET_OBJECT_ID_C: int = 203
+
+PATH: str = 'cmdb.framework.ipam.supernet_membership'
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                    FIXTURES                                                          #
+# -------------------------------------------------------------------------------------------------------------------- #
+def _make_cmdb_object(public_id: int, type_id: int) -> dict[str, Any]:
+    """Builds a minimal CmdbObject doc with the given public_id and type_id."""
+    return {
+        CmdbObjectKey.PUBLIC_ID: public_id,
+        CmdbObjectKey.TYPE_ID: type_id,
+        CmdbObjectKey.FIELDS: [],
+    }
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            normalize_subnet_id_list                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_normalize_subnet_id_list_accepts_ordered_unique_int_list() -> None:
+    """A clean integer list passes through unchanged in input order"""
+    result = normalize_subnet_id_list([SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B, SUBNET_OBJECT_ID_C])
+
+    assert result == [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B, SUBNET_OBJECT_ID_C]
+
+
+def test_normalize_subnet_id_list_collapses_duplicates_preserving_first_occurrence_order() -> None:
+    """Duplicate ids are dropped while the order of the first occurrence is preserved"""
+    result = normalize_subnet_id_list([
+        SUBNET_OBJECT_ID_B,
+        SUBNET_OBJECT_ID_A,
+        SUBNET_OBJECT_ID_B,
+        SUBNET_OBJECT_ID_C,
+        SUBNET_OBJECT_ID_A,
+    ])
+
+    assert result == [SUBNET_OBJECT_ID_B, SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_C]
+
+
+@pytest.mark.parametrize('raw', [None, '', 'subnet-ids', 42, {'subnet_ids': [1]}])
+def test_normalize_subnet_id_list_aborts_400_when_payload_is_not_a_list(raw: Any) -> None:
+    """A non-list payload (None, str, int, dict) aborts 400 without further parsing"""
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_subnet_id_list(raw)
+
+    assert exc_info.value.code == 400
+
+
+def test_normalize_subnet_id_list_aborts_400_for_empty_list() -> None:
+    """An empty list is rejected: the route is a no-op if nothing is selected, so the caller is wrong"""
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_subnet_id_list([])
+
+    assert exc_info.value.code == 400
+
+
+@pytest.mark.parametrize('entry', ['12', 1.5, None, [1], {'public_id': 1}])
+def test_normalize_subnet_id_list_aborts_400_for_non_integer_entries(entry: Any) -> None:
+    """A non-integer entry (str, float, None, list, dict) aborts 400"""
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_subnet_id_list([SUBNET_OBJECT_ID_A, entry])
+
+    assert exc_info.value.code == 400
+
+
+@pytest.mark.parametrize('entry', [True, False])
+def test_normalize_subnet_id_list_aborts_400_for_boolean_entries(entry: bool) -> None:
+    """Booleans subclass int in Python but must be rejected so True does not silently target id 1"""
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_subnet_id_list([entry])
+
+    assert exc_info.value.code == 400
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               diff_missing_ids                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_diff_missing_ids_returns_empty_when_every_id_is_present() -> None:
+    """When every requested id is present in the result set, nothing is missing"""
+    requested = [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B]
+    present = [
+        _make_cmdb_object(SUBNET_OBJECT_ID_A, SUBNET_TYPE_ID),
+        _make_cmdb_object(SUBNET_OBJECT_ID_B, SUBNET_TYPE_ID),
+    ]
+
+    assert diff_missing_ids(requested, present) == []
+
+
+def test_diff_missing_ids_returns_full_request_when_present_is_empty() -> None:
+    """An empty result set means every requested id is missing"""
+    requested = [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B]
+
+    assert diff_missing_ids(requested, []) == requested
+
+
+def test_diff_missing_ids_returns_only_unmatched_ids_preserving_input_order() -> None:
+    """Partial overlap: only the unmatched ids come back, in caller order"""
+    requested = [SUBNET_OBJECT_ID_C, SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B]
+    present = [_make_cmdb_object(SUBNET_OBJECT_ID_A, SUBNET_TYPE_ID)]
+
+    assert diff_missing_ids(requested, present) == [SUBNET_OBJECT_ID_C, SUBNET_OBJECT_ID_B]
+
+
+def test_diff_missing_ids_treats_docs_without_public_id_as_missing() -> None:
+    """A doc missing its public_id cannot satisfy any requested id"""
+    requested = [SUBNET_OBJECT_ID_A]
+    present = [{CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID, CmdbObjectKey.FIELDS: []}]
+
+    assert diff_missing_ids(requested, present) == [SUBNET_OBJECT_ID_A]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            assert_supernet_exists                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_assert_supernet_exists_aborts_400_when_supernet_type_not_defined() -> None:
+    """No SUPERNET CmdbType → HTTP 400; no object query is issued"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    types_manager.get_one_by.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_supernet_exists(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+
+    assert exc_info.value.code == 400
+    objects_manager.find_objects.assert_not_called()
+
+
+def test_assert_supernet_exists_aborts_404_when_object_not_found() -> None:
+    """find_objects returns empty → HTTP 404"""
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = []
+    types_manager = MagicMock()
+    types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUPERNET_TYPE_ID}
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_supernet_exists(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+
+    assert exc_info.value.code == 404
+
+
+def test_assert_supernet_exists_aborts_400_when_object_is_not_a_supernet() -> None:
+    """Found object exists but has a different type_id → HTTP 400"""
+    wrong_type_doc = _make_cmdb_object(SUPERNET_OBJECT_ID, type_id=SUPERNET_TYPE_ID + 1)
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = [wrong_type_doc]
+    types_manager = MagicMock()
+    types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUPERNET_TYPE_ID}
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_supernet_exists(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+
+    assert exc_info.value.code == 400
+
+
+def test_assert_supernet_exists_returns_none_on_happy_path() -> None:
+    """A correct SUPERNET object id returns None (no abort) and queries are well-shaped"""
+    supernet_doc = _make_cmdb_object(SUPERNET_OBJECT_ID, SUPERNET_TYPE_ID)
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = [supernet_doc]
+    types_manager = MagicMock()
+    types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUPERNET_TYPE_ID}
+
+    assert_supernet_exists(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+
+    objects_manager.find_objects.assert_called_once_with(
+        {CmdbObjectKey.PUBLIC_ID: SUPERNET_OBJECT_ID}, as_dict=True,
+    )
+    types_manager.get_one_by.assert_called_once_with({TypeSchemaKey.SPECIAL_TYPE: SpecialType.SUPERNET})
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             load_assigned_subnets                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_load_assigned_subnets_returns_empty_when_subnet_type_not_defined() -> None:
+    """No SUBNET CmdbType → empty list, no DB query for objects"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    types_manager.get_one_by.return_value = None
+
+    result = load_assigned_subnets(
+        objects_manager, types_manager, SUPERNET_OBJECT_ID, [SUBNET_OBJECT_ID_A],
+    )
+
+    assert result == []
+    objects_manager.find_objects.assert_not_called()
+
+
+def test_load_assigned_subnets_returns_manager_result_when_type_defined() -> None:
+    """SUBNET type defined → result of objects_manager.find_objects is returned verbatim"""
+    docs = [_make_cmdb_object(SUBNET_OBJECT_ID_A, SUBNET_TYPE_ID)]
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = docs
+    types_manager = MagicMock()
+    types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUBNET_TYPE_ID}
+
+    result = load_assigned_subnets(
+        objects_manager, types_manager, SUPERNET_OBJECT_ID, [SUBNET_OBJECT_ID_A],
+    )
+
+    assert result is docs
+
+
+def test_load_assigned_subnets_queries_with_public_id_type_and_supernet_ref_filter() -> None:
+    """Mongo filter pins public_id $in, TYPE_ID, plus FIELDS $elemMatch on PARENT_SUPERNET/value"""
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = []
+    types_manager = MagicMock()
+    types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUBNET_TYPE_ID}
+
+    subnet_ids = [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B]
+    load_assigned_subnets(objects_manager, types_manager, SUPERNET_OBJECT_ID, subnet_ids)
+
+    objects_manager.find_objects.assert_called_once_with(
+        {
+            CmdbObjectKey.PUBLIC_ID: {'$in': subnet_ids},
+            CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID,
+            CmdbObjectKey.FIELDS: {
+                '$elemMatch': {
+                    CmdbObjectFieldKey.NAME: SubnetField.PARENT_SUPERNET,
+                    CmdbObjectFieldKey.VALUE: SUPERNET_OBJECT_ID,
+                },
+            },
+        },
+        as_dict=True,
+    )
+    types_manager.get_one_by.assert_called_once_with({TypeSchemaKey.SPECIAL_TYPE: SpecialType.SUBNET})
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              clear_supernet_ref                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_clear_supernet_ref_issues_one_update_many_raw_call() -> None:
+    """The clear is a single Mongo write, not one-update-per-id"""
+    objects_manager = MagicMock()
+
+    clear_supernet_ref(
+        objects_manager,
+        [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B],
+        SUPERNET_OBJECT_ID,
+    )
+
+    assert objects_manager.update_many_raw.call_count == 1
+
+
+def test_clear_supernet_ref_filter_pins_ids_and_current_supernet_value() -> None:
+    """Doc filter requires public_id $in AND dg-supernet-ref currently equals supernet id (TOCTOU-safe)"""
+    objects_manager = MagicMock()
+    subnet_ids = [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B]
+
+    clear_supernet_ref(objects_manager, subnet_ids, SUPERNET_OBJECT_ID)
+
+    call_kwargs = objects_manager.update_many_raw.call_args.kwargs
+    assert call_kwargs['filter_query'] == {
+        CmdbObjectKey.PUBLIC_ID: {'$in': subnet_ids},
+        CmdbObjectKey.FIELDS: {
+            '$elemMatch': {
+                CmdbObjectFieldKey.NAME: SubnetField.PARENT_SUPERNET,
+                CmdbObjectFieldKey.VALUE: SUPERNET_OBJECT_ID,
+            },
+        },
+    }
+
+
+def test_clear_supernet_ref_update_sets_value_to_none() -> None:
+    """The update sets the targeted field entry's value to None (not '' or missing)"""
+    objects_manager = MagicMock()
+
+    clear_supernet_ref(objects_manager, [SUBNET_OBJECT_ID_A], SUPERNET_OBJECT_ID)
+
+    call_kwargs = objects_manager.update_many_raw.call_args.kwargs
+    assert call_kwargs['update'] == {'$set': {'fields.$[f].value': None}}
+
+
+def test_clear_supernet_ref_array_filter_restricts_to_supernet_ref_field_at_current_value() -> None:
+    """Array filter pins both name and current value so only the dg-supernet-ref entry is cleared"""
+    objects_manager = MagicMock()
+
+    clear_supernet_ref(objects_manager, [SUBNET_OBJECT_ID_A], SUPERNET_OBJECT_ID)
+
+    call_kwargs = objects_manager.update_many_raw.call_args.kwargs
+    assert call_kwargs['array_filters'] == [{
+        'f.name': SubnetField.PARENT_SUPERNET,
+        'f.value': SUPERNET_OBJECT_ID,
+    }]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                       unassign_subnets_from_supernet                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_unassign_subnets_from_supernet_returns_dedup_ids_and_count_on_happy_path() -> None:
+    """Happy path returns the deduped subnet_ids and the matching unassigned_count"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    assigned_docs = [
+        _make_cmdb_object(SUBNET_OBJECT_ID_A, SUBNET_TYPE_ID),
+        _make_cmdb_object(SUBNET_OBJECT_ID_B, SUBNET_TYPE_ID),
+    ]
+
+    with patch(f'{PATH}.assert_supernet_exists') as assert_mock, \
+         patch(f'{PATH}.load_assigned_subnets', return_value=assigned_docs) as load_mock, \
+         patch(f'{PATH}.clear_supernet_ref') as clear_mock:
+        result = unassign_subnets_from_supernet(
+            objects_manager,
+            types_manager,
+            SUPERNET_OBJECT_ID,
+            [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B, SUBNET_OBJECT_ID_A],
+        )
+
+    assert result == {
+        IpamUnassignKey.SUBNET_IDS: [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B],
+        IpamUnassignKey.UNASSIGNED_COUNT: 2,
+    }
+    assert_mock.assert_called_once_with(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+    load_mock.assert_called_once_with(
+        objects_manager, types_manager, SUPERNET_OBJECT_ID,
+        [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B],
+    )
+    clear_mock.assert_called_once_with(
+        objects_manager, [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B], SUPERNET_OBJECT_ID,
+    )
+
+
+def test_unassign_subnets_from_supernet_propagates_payload_normalization_aborts() -> None:
+    """An invalid payload aborts before any DB call (no supernet check, no load, no clear)"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+
+    with patch(f'{PATH}.assert_supernet_exists') as assert_mock, \
+         patch(f'{PATH}.load_assigned_subnets') as load_mock, \
+         patch(f'{PATH}.clear_supernet_ref') as clear_mock, \
+         pytest.raises(HTTPException) as exc_info:
+        unassign_subnets_from_supernet(objects_manager, types_manager, SUPERNET_OBJECT_ID, None)
+
+    assert exc_info.value.code == 400
+    assert_mock.assert_not_called()
+    load_mock.assert_not_called()
+    clear_mock.assert_not_called()
+
+
+def test_unassign_subnets_from_supernet_propagates_supernet_assertion_aborts() -> None:
+    """A supernet-existence abort surfaces unchanged and no load / no clear is issued"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+
+    with patch(f'{PATH}.assert_supernet_exists', side_effect=NotFound('not found')), \
+         patch(f'{PATH}.load_assigned_subnets') as load_mock, \
+         patch(f'{PATH}.clear_supernet_ref') as clear_mock, \
+         pytest.raises(HTTPException) as exc_info:
+        unassign_subnets_from_supernet(
+            objects_manager, types_manager, SUPERNET_OBJECT_ID, [SUBNET_OBJECT_ID_A],
+        )
+
+    assert exc_info.value.code == 404
+    load_mock.assert_not_called()
+    clear_mock.assert_not_called()
+
+
+def test_unassign_subnets_from_supernet_aborts_400_when_any_id_is_unassignable() -> None:
+    """Validate-all-or-nothing: any unassignable id aborts 400 and clear_supernet_ref is NOT called"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    assigned_docs = [_make_cmdb_object(SUBNET_OBJECT_ID_A, SUBNET_TYPE_ID)]
+
+    with patch(f'{PATH}.assert_supernet_exists'), \
+         patch(f'{PATH}.load_assigned_subnets', return_value=assigned_docs), \
+         patch(f'{PATH}.clear_supernet_ref') as clear_mock, \
+         pytest.raises(HTTPException) as exc_info:
+        unassign_subnets_from_supernet(
+            objects_manager,
+            types_manager,
+            SUPERNET_OBJECT_ID,
+            [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B],
+        )
+
+    assert exc_info.value.code == 400
+    clear_mock.assert_not_called()

--- a/tests/unit/framework/ipam/test_supernet_overview.py
+++ b/tests/unit/framework/ipam/test_supernet_overview.py
@@ -30,7 +30,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from werkzeug.exceptions import HTTPException
+from werkzeug.exceptions import HTTPException, NotFound
 
 from cmdb.models.object_model import (
     CmdbObjectKey,
@@ -51,9 +51,12 @@ from cmdb.models.special_type_model.ipam_constants import (
 )
 from cmdb.models.type_model.type_schema_key_enum import TypeSchemaKey
 from cmdb.framework.ipam.supernet_overview import (
+    _active_search,
     _annotate_has_children,
+    _annotate_is_valid,
     _attach_vlans_to_rows,
     _build_linked_subnet_rows,
+    _count_invalid_rows,
     _count_used_ips_per_subnet,
     _filter_rows_by_network_substring,
     _index_children_by_parent,
@@ -64,9 +67,13 @@ from cmdb.framework.ipam.supernet_overview import (
     _paginate_rows,
     _parse_supernet_cidr,
     _percent,
+    _prepare_supernet_view,
     _row_subnet_ref,
+    _select_invalid_listed_rows,
+    _select_invalid_rows,
     _select_listed_rows,
     _summarize_supernet,
+    build_invalid_subnet_overview,
     build_supernet_overview,
     build_supernet_subnet_children,
     compute_subnet_row,
@@ -493,6 +500,150 @@ def test_annotate_has_children_sets_false_for_row_with_missing_public_id() -> No
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
+#                                             _annotate_is_valid                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_annotate_is_valid_sets_true_for_row_strictly_inside_supernet() -> None:
+    """A row whose CIDR sits strictly inside the supernet network gets is_valid=True"""
+    row = _make_row(1, SUBNET_RANGE_A)
+
+    _annotate_is_valid([row], IPv4Network(SUPERNET_RANGE))
+
+    assert row[IpamOverviewKey.IS_VALID] is True
+
+
+def test_annotate_is_valid_sets_false_for_row_equal_to_supernet() -> None:
+    """A row whose CIDR exactly matches the supernet is NOT strictly contained -> False"""
+    row = _make_row(1, SUPERNET_RANGE)
+
+    _annotate_is_valid([row], IPv4Network(SUPERNET_RANGE))
+
+    assert row[IpamOverviewKey.IS_VALID] is False
+
+
+def test_annotate_is_valid_sets_false_for_row_outside_supernet() -> None:
+    """A row whose CIDR falls outside the supernet network gets is_valid=False"""
+    row = _make_row(1, '192.168.1.0/24')
+
+    _annotate_is_valid([row], IPv4Network(SUPERNET_RANGE))
+
+    assert row[IpamOverviewKey.IS_VALID] is False
+
+
+def test_annotate_is_valid_sets_false_for_row_with_unparsable_cidr() -> None:
+    """A row whose 'cidr' is not a canonical CIDR string is invalid"""
+    row = _make_row(1, 'not-a-cidr')
+
+    _annotate_is_valid([row], IPv4Network(SUPERNET_RANGE))
+
+    assert row[IpamOverviewKey.IS_VALID] is False
+
+
+def test_annotate_is_valid_sets_false_for_row_with_non_string_cidr() -> None:
+    """A row whose 'cidr' is None (or any non-string) is invalid"""
+    row = _make_row(1, None)
+
+    _annotate_is_valid([row], IPv4Network(SUPERNET_RANGE))
+
+    assert row[IpamOverviewKey.IS_VALID] is False
+
+
+def test_annotate_is_valid_sets_false_for_every_row_when_supernet_network_is_none() -> None:
+    """A supernet network of None (CIDR missing or unparsable) flips every row to False"""
+    row_inside = _make_row(1, SUBNET_RANGE_A)
+    row_outside = _make_row(2, '192.168.1.0/24')
+
+    _annotate_is_valid([row_inside, row_outside], None)
+
+    assert row_inside[IpamOverviewKey.IS_VALID] is False
+    assert row_outside[IpamOverviewKey.IS_VALID] is False
+
+
+def test_annotate_is_valid_mutates_rows_in_place() -> None:
+    """The annotator mutates each row directly; the IS_VALID key is set on every supplied dict"""
+    row = _make_row(1, SUBNET_RANGE_A)
+
+    _annotate_is_valid([row], IPv4Network(SUPERNET_RANGE))
+
+    assert IpamOverviewKey.IS_VALID in row
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             _count_invalid_rows                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_count_invalid_rows_returns_zero_for_empty_list() -> None:
+    """No rows -> zero invalid"""
+    assert _count_invalid_rows([]) == 0
+
+
+def test_count_invalid_rows_returns_zero_when_every_row_is_valid() -> None:
+    """All rows marked valid -> zero invalid"""
+    rows = [
+        {**_make_row(1, SUBNET_RANGE_A), IpamOverviewKey.IS_VALID: True},
+        {**_make_row(2, SUBNET_RANGE_B), IpamOverviewKey.IS_VALID: True},
+    ]
+
+    assert _count_invalid_rows(rows) == 0
+
+
+def test_count_invalid_rows_counts_only_invalid_rows_in_mixed_input() -> None:
+    """Mixed valid/invalid rows -> exact invalid count"""
+    rows = [
+        {**_make_row(1, SUBNET_RANGE_A), IpamOverviewKey.IS_VALID: True},
+        {**_make_row(2, SUBNET_RANGE_B), IpamOverviewKey.IS_VALID: False},
+        {**_make_row(3, '192.168.1.0/24'), IpamOverviewKey.IS_VALID: False},
+    ]
+
+    assert _count_invalid_rows(rows) == 2
+
+
+def test_count_invalid_rows_counts_rows_missing_the_key_as_invalid() -> None:
+    """A row without the is_valid key is counted as invalid (defensive against unannotated input)"""
+    rows = [
+        {**_make_row(1, SUBNET_RANGE_A), IpamOverviewKey.IS_VALID: True},
+        _make_row(2, SUBNET_RANGE_B),
+    ]
+
+    assert _count_invalid_rows(rows) == 1
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             _select_invalid_rows                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_select_invalid_rows_returns_empty_for_empty_input() -> None:
+    """No rows -> empty list"""
+    assert _select_invalid_rows([]) == []
+
+
+def test_select_invalid_rows_returns_empty_when_every_row_is_valid() -> None:
+    """All-valid input -> empty list"""
+    rows = [
+        {**_make_row(1, SUBNET_RANGE_A), IpamOverviewKey.IS_VALID: True},
+        {**_make_row(2, SUBNET_RANGE_B), IpamOverviewKey.IS_VALID: True},
+    ]
+
+    assert _select_invalid_rows(rows) == []
+
+
+def test_select_invalid_rows_returns_invalid_subset_preserving_input_order() -> None:
+    """Mixed input -> only invalid rows come back, in their original order"""
+    valid_a = {**_make_row(1, SUBNET_RANGE_A), IpamOverviewKey.IS_VALID: True}
+    invalid_b = {**_make_row(2, SUBNET_RANGE_B), IpamOverviewKey.IS_VALID: False}
+    invalid_c = {**_make_row(3, '192.168.1.0/24'), IpamOverviewKey.IS_VALID: False}
+
+    result = _select_invalid_rows([invalid_b, valid_a, invalid_c])
+
+    assert result == [invalid_b, invalid_c]
+
+
+def test_select_invalid_rows_includes_rows_missing_the_key() -> None:
+    """A row without the is_valid key is included (defensive against unannotated input)"""
+    annotated_valid = {**_make_row(1, SUBNET_RANGE_A), IpamOverviewKey.IS_VALID: True}
+    unannotated = _make_row(2, SUBNET_RANGE_B)
+
+    assert _select_invalid_rows([annotated_valid, unannotated]) == [unannotated]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
 #                                       _filter_rows_by_network_substring                                              #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_filter_rows_by_network_substring_returns_empty_for_empty_input() -> None:
@@ -545,6 +696,47 @@ def test_filter_rows_by_network_substring_matches_unparsable_string_cidr() -> No
     rows = [{CmdbObjectKey.PUBLIC_ID: 1, IpamOverviewKey.CIDR: 'not-a-cidr'}]
 
     assert _filter_rows_by_network_substring(rows, 'cidr') == rows
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               _active_search                                                         #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_active_search_returns_none_for_none_input() -> None:
+    """None coerces to '' and falls below the min-length gate"""
+    assert _active_search(None) is None  # type: ignore[arg-type]
+
+
+def test_active_search_returns_none_for_empty_string() -> None:
+    """An empty string is never active"""
+    assert _active_search('') is None
+
+
+def test_active_search_returns_none_for_whitespace_only_input() -> None:
+    """Whitespace strips to empty -> not active"""
+    assert _active_search('   ') is None
+
+
+def test_active_search_returns_none_for_query_below_min_length() -> None:
+    """A 1-char query (with MIN_QUERY_LENGTH=2) is not yet active"""
+    assert IpamSearch.MIN_QUERY_LENGTH == 2  # pinning the policy this test depends on
+    assert _active_search('1') is None
+
+
+def test_active_search_returns_stripped_needle_at_min_length() -> None:
+    """A query exactly at MIN_QUERY_LENGTH becomes active and is returned stripped"""
+    assert _active_search('  ab  ') == 'ab'
+
+
+def test_active_search_returns_stripped_needle_above_min_length() -> None:
+    """A longer query is returned stripped of surrounding whitespace"""
+    assert _active_search('  10.0  ') == '10.0'
+
+
+def test_active_search_does_not_truncate_at_max_query_length() -> None:
+    """MAX_QUERY_LENGTH clipping is the route's job, not the helper's"""
+    long_query: str = 'x' * (IpamSearch.MAX_QUERY_LENGTH + 50)
+
+    assert _active_search(long_query) == long_query
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -603,6 +795,65 @@ def test_select_listed_rows_strips_search_before_min_length_check() -> None:
     nested = _make_nested_row(2, '10.0.0.0/25', parent_id=1)
 
     assert _select_listed_rows([top, nested], '  1  ') == [top]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                           _select_invalid_listed_rows                                                #
+# -------------------------------------------------------------------------------------------------------------------- #
+def _make_annotated_row(public_id: int, cidr: str, is_valid: bool) -> dict[str, Any]:
+    """Returns an overview row pre-annotated with parent_id=None and is_valid for selection tests."""
+    return {
+        **_make_row(public_id, cidr),
+        IpamOverviewKey.PARENT_ID: None,
+        IpamOverviewKey.IS_VALID: is_valid,
+    }
+
+
+def test_select_invalid_listed_rows_returns_only_invalid_when_search_is_empty() -> None:
+    """No search -> every invalid row, in input order; valid rows never leak through"""
+    valid = _make_annotated_row(1, SUBNET_RANGE_A, is_valid=True)
+    invalid_a = _make_annotated_row(2, '192.168.0.0/24', is_valid=False)
+    invalid_b = _make_annotated_row(3, '192.168.1.0/24', is_valid=False)
+
+    assert _select_invalid_listed_rows([valid, invalid_a, invalid_b], '') == [invalid_a, invalid_b]
+
+
+def test_select_invalid_listed_rows_returns_all_invalid_for_whitespace_only_search() -> None:
+    """A whitespace search strips to empty and falls back to the full invalid set"""
+    invalid_a = _make_annotated_row(1, '192.168.0.0/24', is_valid=False)
+    invalid_b = _make_annotated_row(2, '192.168.1.0/24', is_valid=False)
+
+    assert _select_invalid_listed_rows([invalid_a, invalid_b], '   ') == [invalid_a, invalid_b]
+
+
+def test_select_invalid_listed_rows_falls_back_when_search_below_min_length() -> None:
+    """A 1-char query is below MIN_QUERY_LENGTH and is ignored - full invalid set is returned"""
+    invalid_a = _make_annotated_row(1, '192.168.0.0/24', is_valid=False)
+    invalid_b = _make_annotated_row(2, '10.0.5.0/24', is_valid=False)
+
+    assert _select_invalid_listed_rows([invalid_a, invalid_b], '1') == [invalid_a, invalid_b]
+
+
+def test_select_invalid_listed_rows_substring_filters_within_invalid_subset_only() -> None:
+    """Active search filters by substring AGAINST THE INVALID SUBSET; valid matches never leak"""
+    valid_match = _make_annotated_row(1, '10.0.0.0/24', is_valid=True)
+    invalid_match = _make_annotated_row(2, '10.0.5.0/24', is_valid=False)
+    invalid_no_match = _make_annotated_row(3, '192.168.0.0/24', is_valid=False)
+
+    result = _select_invalid_listed_rows([valid_match, invalid_match, invalid_no_match], '10.0')
+
+    assert result == [invalid_match]
+
+
+def test_select_invalid_listed_rows_returns_empty_when_no_invalid_rows() -> None:
+    """An all-valid input yields an empty list regardless of search activation"""
+    rows = [
+        _make_annotated_row(1, SUBNET_RANGE_A, is_valid=True),
+        _make_annotated_row(2, SUBNET_RANGE_B, is_valid=True),
+    ]
+
+    assert _select_invalid_listed_rows(rows, '') == []
+    assert _select_invalid_listed_rows(rows, '10.0') == []
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -1178,12 +1429,90 @@ def test_summarize_supernet_forwards_none_network_unchanged() -> None:
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
+#                                            _prepare_supernet_view                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_prepare_supernet_view_propagates_load_supernet_aborts() -> None:
+    """An abort raised by _load_supernet_object propagates out of the prep helper"""
+    with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
+         pytest.raises(HTTPException) as exc_info:
+        _prepare_supernet_view(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert exc_info.value.code == 404
+
+
+def test_prepare_supernet_view_returns_four_tuple_with_expected_types() -> None:
+    """Tuple shape: (supernet doc, annotated rows list, summary dict, invalid count int)"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_in = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_in]):
+        returned_doc, rows, summary, invalid_count = _prepare_supernet_view(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID,
+        )
+
+    assert returned_doc is supernet_doc
+    assert rows == [row_in]
+    assert isinstance(summary, dict)
+    assert isinstance(invalid_count, int)
+
+
+def test_prepare_supernet_view_annotates_rows_with_has_children_and_is_valid_before_returning() -> None:
+    """Every returned row carries both annotations regardless of CIDR validity"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.USED_IPS: 0}
+    row_outside = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'), IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_valid, row_outside]):
+        _, rows, _summary, _invalid = _prepare_supernet_view(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID,
+        )
+
+    for row in rows:
+        assert IpamOverviewKey.HAS_CHILDREN in row
+        assert IpamOverviewKey.IS_VALID in row
+
+
+def test_prepare_supernet_view_returns_invalid_count_matching_annotated_rows() -> None:
+    """invalid_count is the number of rows whose is_valid annotation came out False"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.USED_IPS: 0}
+    row_outside = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'), IpamOverviewKey.USED_IPS: 0}
+    row_unparsable = {**_make_row(99, 'not-a-cidr'), IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(
+             f'{PATH}._build_linked_subnet_rows',
+             return_value=[row_valid, row_outside, row_unparsable],
+         ):
+        _, _rows, _summary, invalid_count = _prepare_supernet_view(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID,
+        )
+
+    assert invalid_count == 2
+
+
+def test_prepare_supernet_view_marks_every_row_invalid_when_supernet_cidr_unparsable() -> None:
+    """A supernet with a missing or unparsable CIDR makes every row invalid"""
+    broken_supernet = _make_supernet_doc(SUPERNET_OBJECT_ID, 'not-a-cidr')
+    row_in = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=broken_supernet), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_in]):
+        _, rows, _summary, invalid_count = _prepare_supernet_view(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID,
+        )
+
+    assert invalid_count == 1
+    assert rows[0][IpamOverviewKey.IS_VALID] is False
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
 #                                          build_supernet_overview                                                     #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_build_supernet_overview_propagates_load_supernet_aborts() -> None:
     """An abort raised by _load_supernet_object propagates out of the orchestrator"""
-    from werkzeug.exceptions import NotFound
-
     with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
          pytest.raises(HTTPException) as exc_info:
         build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
@@ -1205,7 +1534,11 @@ def test_build_supernet_overview_returns_payload_with_supernet_and_subnets_block
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_nested, row_b]):
         payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
-    assert set(payload.keys()) == {IpamOverviewKey.SUPERNET, IpamOverviewKey.SUBNETS}
+    assert set(payload.keys()) == {
+        IpamOverviewKey.SUPERNET,
+        IpamOverviewKey.SUBNETS,
+        IpamOverviewKey.INVALID_COUNT,
+    }
     assert payload[IpamOverviewKey.SUPERNET][CmdbObjectKey.PUBLIC_ID] == SUPERNET_OBJECT_ID
     top_rows = payload[IpamOverviewKey.SUBNETS][IpamOverviewKey.ROWS]
     top_ids = {r[CmdbObjectKey.PUBLIC_ID] for r in top_rows}
@@ -1394,13 +1727,68 @@ def test_build_supernet_overview_paginates_flat_search_results() -> None:
     assert len(subnets_block[IpamOverviewKey.ROWS]) == 1
 
 
+def test_build_supernet_overview_annotates_is_valid_on_top_level_rows() -> None:
+    """Every row in the page carries an is_valid boolean populated against the supernet network"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_inside = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.PARENT_ID: None,
+                  IpamOverviewKey.USED_IPS: 0}
+    row_outside = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'), IpamOverviewKey.PARENT_ID: None,
+                   IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_inside, row_outside]):
+        payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    rows_by_id = {r[CmdbObjectKey.PUBLIC_ID]: r for r in payload[IpamOverviewKey.SUBNETS][IpamOverviewKey.ROWS]}
+    assert rows_by_id[SUBNET_OBJECT_ID_A][IpamOverviewKey.IS_VALID] is True
+    assert rows_by_id[SUBNET_OBJECT_ID_B][IpamOverviewKey.IS_VALID] is False
+
+
+def test_build_supernet_overview_invalid_count_reflects_all_nesting_depths() -> None:
+    """invalid_count is computed over all subnets, including nested ones not on the top-level page"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_top_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.PARENT_ID: None,
+                     IpamOverviewKey.USED_IPS: 0}
+    row_nested_invalid = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, '192.168.0.0/25'),
+                          IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 0}
+    row_top_invalid = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'),
+                       IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(
+             f'{PATH}._build_linked_subnet_rows',
+             return_value=[row_top_valid, row_nested_invalid, row_top_invalid],
+         ):
+        payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert payload[IpamOverviewKey.INVALID_COUNT] == 2
+
+
+def test_build_supernet_overview_invalid_count_is_invariant_under_search() -> None:
+    """invalid_count is global; an active search shrinks subnets.total but not invalid_count"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_invalid_a = {**_make_row(SUBNET_OBJECT_ID_A, '192.168.0.0/24'),
+                     IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+    row_invalid_b = {**_make_row(SUBNET_OBJECT_ID_B, '172.16.0.0/24'),
+                     IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_invalid_a, row_invalid_b]):
+        no_search = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+        with_search = build_supernet_overview(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, search='192.168',
+        )
+
+    assert no_search[IpamOverviewKey.INVALID_COUNT] == 2
+    assert with_search[IpamOverviewKey.INVALID_COUNT] == 2
+    assert with_search[IpamOverviewKey.SUBNETS][IpamOverviewKey.TOTAL] == 1
+
+
 # -------------------------------------------------------------------------------------------------------------------- #
 #                                       build_supernet_subnet_children                                                 #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_build_supernet_subnet_children_propagates_load_supernet_aborts() -> None:
     """An abort raised by _load_supernet_object propagates out of the children orchestrator"""
-    from werkzeug.exceptions import NotFound
-
     with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
          pytest.raises(HTTPException) as exc_info:
         build_supernet_subnet_children(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, SUBNET_OBJECT_ID_A)
@@ -1453,3 +1841,164 @@ def test_build_supernet_subnet_children_returns_empty_rows_when_subnet_has_no_ch
         )
 
     assert payload[IpamOverviewKey.ROWS] == []
+
+
+def test_build_supernet_subnet_children_annotates_is_valid_on_child_rows() -> None:
+    """Each child row carries is_valid against the supernet's network"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_a = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.PARENT_ID: None,
+             IpamOverviewKey.USED_IPS: 0}
+    child_inside = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, NESTED_IN_A_RANGE),
+                    IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, child_inside]):
+        payload = build_supernet_subnet_children(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, SUBNET_OBJECT_ID_A,
+        )
+
+    child_rows = payload[IpamOverviewKey.ROWS]
+    assert all(IpamOverviewKey.IS_VALID in r for r in child_rows)
+    assert child_rows[0][IpamOverviewKey.IS_VALID] is True
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                       build_invalid_subnet_overview                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_build_invalid_subnet_overview_propagates_load_supernet_aborts() -> None:
+    """An abort raised by _load_supernet_object propagates out of the orchestrator"""
+    with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
+         pytest.raises(HTTPException) as exc_info:
+        build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert exc_info.value.code == 404
+
+
+def test_build_invalid_subnet_overview_returns_envelope_keys_matching_main_overview() -> None:
+    """Same top-level keys as build_supernet_overview: supernet, subnets, invalid_count"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_invalid = {**_make_row(SUBNET_OBJECT_ID_A, '192.168.0.0/24'),
+                   IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_invalid]):
+        payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert set(payload.keys()) == {
+        IpamOverviewKey.SUPERNET,
+        IpamOverviewKey.SUBNETS,
+        IpamOverviewKey.INVALID_COUNT,
+    }
+    assert payload[IpamOverviewKey.SUPERNET][CmdbObjectKey.PUBLIC_ID] == SUPERNET_OBJECT_ID
+
+
+def test_build_invalid_subnet_overview_returns_only_invalid_subnets_in_rows() -> None:
+    """Rows are the flat list of subnets whose CIDR does not sit inside the supernet"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A),
+                 IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+    row_invalid_top = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.0.0/24'),
+                       IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+    row_invalid_nested = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, '172.16.0.0/24'),
+                          IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A,
+                          IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(
+             f'{PATH}._build_linked_subnet_rows',
+             return_value=[row_valid, row_invalid_top, row_invalid_nested],
+         ):
+        payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    rows = payload[IpamOverviewKey.SUBNETS][IpamOverviewKey.ROWS]
+    assert [r[CmdbObjectKey.PUBLIC_ID] for r in rows] == [SUBNET_OBJECT_ID_B, SUBNET_OBJECT_ID_NESTED_IN_A]
+    assert all(r[IpamOverviewKey.IS_VALID] is False for r in rows)
+
+
+def test_build_invalid_subnet_overview_returns_empty_rows_when_every_subnet_is_valid() -> None:
+    """An entirely-valid input yields total=0 and an empty rows list; envelope still emits"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A),
+                 IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_valid]):
+        payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert payload[IpamOverviewKey.SUBNETS][IpamOverviewKey.TOTAL] == 0
+    assert payload[IpamOverviewKey.SUBNETS][IpamOverviewKey.ROWS] == []
+    assert payload[IpamOverviewKey.INVALID_COUNT] == 0
+
+
+def test_build_invalid_subnet_overview_kpi_summary_matches_main_overview() -> None:
+    """The 'supernet' KPI block is computed over ALL subnets, identical to build_supernet_overview"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    row_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A),
+                 IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 4}
+    row_invalid = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.0.0/24'),
+                   IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 2}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_valid, row_invalid]):
+        main_payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+        invalid_payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert main_payload[IpamOverviewKey.SUPERNET] == invalid_payload[IpamOverviewKey.SUPERNET]
+
+
+def test_build_invalid_subnet_overview_paginates_the_invalid_list() -> None:
+    """page / page_size clamp the rows slice; subnets.total reflects the full invalid count"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    invalid_rows = [
+        {**_make_row(201, '192.168.0.0/24'), IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0},
+        {**_make_row(202, '192.168.1.0/24'), IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0},
+        {**_make_row(203, '192.168.2.0/24'), IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0},
+    ]
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=invalid_rows):
+        payload = build_invalid_subnet_overview(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, page=1, page_size=2,
+        )
+
+    subnets_block = payload[IpamOverviewKey.SUBNETS]
+    assert subnets_block[IpamOverviewKey.PAGE_SIZE] == 2
+    assert subnets_block[IpamOverviewKey.TOTAL] == 3
+    assert len(subnets_block[IpamOverviewKey.ROWS]) == 2
+    assert payload[IpamOverviewKey.INVALID_COUNT] == 3
+
+
+def test_build_invalid_subnet_overview_search_filters_subnets_total_but_not_invalid_count() -> None:
+    """Active search shrinks subnets.total to substring-matching invalid rows; invalid_count stays global"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
+    invalid_192 = {**_make_row(201, '192.168.0.0/24'),
+                   IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+    invalid_172 = {**_make_row(202, '172.16.0.0/24'),
+                   IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[invalid_192, invalid_172]):
+        payload = build_invalid_subnet_overview(
+            MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, search='192.168',
+        )
+
+    subnets_block = payload[IpamOverviewKey.SUBNETS]
+    assert subnets_block[IpamOverviewKey.TOTAL] == 1
+    assert [r[CmdbObjectKey.PUBLIC_ID] for r in subnets_block[IpamOverviewKey.ROWS]] == [201]
+    assert payload[IpamOverviewKey.INVALID_COUNT] == 2
+
+
+def test_build_invalid_subnet_overview_marks_every_row_invalid_when_supernet_cidr_missing() -> None:
+    """A supernet with an unparsable CIDR makes every subnet invalid (rows == every subnet)"""
+    broken_supernet = _make_supernet_doc(SUPERNET_OBJECT_ID, 'not-a-cidr')
+    row_a = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A),
+             IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+    row_b = {**_make_row(SUBNET_OBJECT_ID_B, SUBNET_RANGE_B),
+             IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
+
+    with patch(f'{PATH}._load_supernet_object', return_value=broken_supernet), \
+         patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_b]):
+        payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert payload[IpamOverviewKey.INVALID_COUNT] == 2
+    assert payload[IpamOverviewKey.SUBNETS][IpamOverviewKey.TOTAL] == 2


### PR DESCRIPTION
Changes:
* added invalid count to supernet overview data
* added is_valid property for each subnet in supernet overview
* Added new route to retrieve only invalid subnets for the corresponding supernet