### PR TITLE
DAT-2646-ip-distribution

### DIFF
--- a/cmdb/framework/ipam/interface_validator.py
+++ b/cmdb/framework/ipam/interface_validator.py
@@ -58,6 +58,7 @@ class InterfaceErrorCode(BaseStrEnum):
     SUBNET_TYPE_MISSING = 'subnet_type_missing'
     SUBNET_NOT_FOUND = 'subnet_not_found'
     SUBNET_BROKEN_STATE = 'subnet_broken_state'
+    SUBNET_WITHOUT_IP = 'subnet_without_ip'
     IP_INVALID = 'ip_invalid'
     IP_NOT_IN_SUBNET = 'ip_not_in_subnet'
     IP_RESERVED = 'ip_reserved'
@@ -436,6 +437,45 @@ def find_intra_submission_duplicates(
     return errors
 
 
+def find_subnet_without_ip(
+    rows: list[tuple[int, int | None, str | None]],
+) -> list[dict[str, Any]]:
+    """
+    Reports interface rows that have a subnet reference selected but no IP address
+
+    A dg-ipam-interface row is considered incomplete when the user picks a subnet but leaves the
+    IP field empty: such a row cannot be checked for CIDR membership, reserved addresses, or
+    uniqueness, and would not contribute to any subnet's used-IP roll-up. The inverse case (IP
+    without subnet) is intentionally not flagged here - that is the literal request scope, and
+    a row with neither field set is treated as a still-empty placeholder row, accepted silently
+    by every caller of this batch validator
+
+    Args:
+        rows (list[tuple[int, int | None, str | None]]): (row_index, subnet_ref, ip) tuples as
+            produced by _extract_interface_rows in cmdb.framework.ipam.enforcement
+
+    Returns:
+        list[dict[str, Any]]: One SUBNET_WITHOUT_IP error per offending row, with details
+            carrying the row index and the orphaned subnet_object_id
+    """
+    errors: list[dict[str, Any]] = []
+
+    for row_index, subnet_ref, ip in rows:
+        if subnet_ref is None or ip is not None:
+            continue
+
+        errors.append(build_error(
+            InterfaceErrorCode.SUBNET_WITHOUT_IP,
+            f"Interface row {row_index} has a subnet selected but no IP address",
+            {
+                IpamValidationDetailKey.ROW_INDEX: row_index,
+                IpamValidationDetailKey.SUBNET_OBJECT_ID: subnet_ref,
+            },
+        ))
+
+    return errors
+
+
 def validate_interface_rows(
     objects_manager: ObjectsManager,
     types_manager: TypesManager,
@@ -446,9 +486,12 @@ def validate_interface_rows(
     Validates a batch of dg-ipam-interface rows belonging to one (in-flight) object
 
     Performs:
-      1. Cross-row duplicate detection via find_intra_submission_duplicates so two rows on the
+      1. Completeness check via find_subnet_without_ip so a row with a subnet picked but no IP
+         is flagged before any DB call. The inverse case (IP without subnet) and entirely empty
+         placeholder rows pass through silently
+      2. Cross-row duplicate detection via find_intra_submission_duplicates so two rows on the
          same form sharing a (subnet, IP) pair are flagged before they hit the DB
-      2. Per-row validation via validate_interface for each row that has both subnet_ref and IP
+      3. Per-row validation via validate_interface for each row that has both subnet_ref and IP
          set; the row's index is injected into every per-row error's 'details.row_index' so the
          caller can map errors back to the originating row
 
@@ -468,7 +511,8 @@ def validate_interface_rows(
     if not rows:
         return []
 
-    errors: list[dict[str, Any]] = find_intra_submission_duplicates(rows)
+    errors: list[dict[str, Any]] = find_subnet_without_ip(rows)
+    errors.extend(find_intra_submission_duplicates(rows))
 
     for row_index, subnet_ref, ip in rows:
         if subnet_ref is None or ip is None:

--- a/cmdb/framework/ipam/subnet_overview.py
+++ b/cmdb/framework/ipam/subnet_overview.py
@@ -833,20 +833,24 @@ def _compute_grid_dimensions(total: int) -> tuple[int, int, int]:
     return ranges_count, sectors_per_range, sector_size
 
 
-def _bucket_used_counts(
+def _bucket_used_by_type(
     assigned: dict[str, dict[str, Any]],
     network: IPv4Network,
     sector_size: int,
     total_cells: int,
-) -> list[int]:
+) -> list[dict[int | None, int]]:
     """
-    Tallies how many assigned IPs fall into each grid cell, indexed by global cell position
+    Tallies assigned IPs per grid cell, broken down by the owning CmdbType id
 
     Walks the assigned map once, computes each IP's offset from the subnet's network address,
-    and integer-divides by 'sector_size' to land in the owning cell. IPs outside the subnet
-    or unparsable are skipped defensively (the caller already filters in
-    _load_assigned_rows_map but this stays robust against future drift). Complexity is O(used)
-    not O(total_cells), so /1 stays cheap
+    and integer-divides by 'sector_size' to land in the owning cell. IPs outside the subnet or
+    unparsable are skipped defensively (the caller already filters in _load_assigned_rows_map
+    but this stays robust against future drift). Within each cell the count is bucketed by the
+    row's type_id: int type_ids are kept as-is, anything else (missing, non-int) collapses into
+    a single ``None`` key so the consumer can route it through the Unknown bucket without a
+    second pass. Resolving the ``None`` key against the live type_meta is the caller's job -
+    this helper only records what the row claims. Complexity is O(used), not O(total_cells), so
+    /1 stays cheap
 
     Args:
         assigned (dict[str, dict[str, Any]]): {ip_str: row_info} as produced by
@@ -856,17 +860,19 @@ def _bucket_used_counts(
         total_cells (int): Number of cells in the grid (ranges_count * sectors_per_range)
 
     Returns:
-        list[int]: Used-IP count per cell, length == total_cells
+        list[dict[int | None, int]]: Per-cell {type_id_or_None: count} breakdowns, indexed by
+            global cell position; length == total_cells. Each breakdown is empty when the cell
+            has no assigned IPs. Summing a breakdown's values yields the cell's used count
     """
-    counts: list[int] = [0] * total_cells
+    breakdowns: list[dict[int | None, int]] = [{} for _ in range(total_cells)]
 
     if total_cells == 0 or sector_size <= 0:
-        return counts
+        return breakdowns
 
     base_int: int = int(network.network_address)
     span: int = total_cells * sector_size
 
-    for ip_str in assigned:
+    for ip_str, info in assigned.items():
         parsed: IPv4Address | None = parse_ipv4(ip_str)
 
         if parsed is None:
@@ -877,45 +883,136 @@ def _bucket_used_counts(
         if offset < 0 or offset >= span:
             continue
 
-        counts[offset // sector_size] += 1
+        raw_type_id: Any = info.get(_AssignedField.TYPE_ID)
+        key: int | None = raw_type_id if isinstance(raw_type_id, int) else None
 
-    return counts
+        cell: dict[int | None, int] = breakdowns[offset // sector_size]
+        cell[key] = cell.get(key, 0) + 1
+
+    return breakdowns
+
+
+def _compose_sector_type_stats(
+    breakdown: dict[int | None, int],
+    type_meta: dict[int, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Shapes the 'type_stats' list for one sector of the 'ip_distribution' grid
+
+    Translates a raw per-cell {type_id_or_None: count} breakdown into the wire-format bucket
+    list emitted next to each sector. Type ids that are int AND present in type_meta become
+    real buckets (carrying public_id, label, ci_explorer_color); anything else (None, or an
+    int that no longer resolves because the CmdbType was deleted) collapses into a single
+    Unknown bucket with public_id=None and ci_explorer_color=None so the chart never grows a
+    slice per stale type_id. Mirrors the Unknown-collapsing rule of _build_type_distribution
+    so the per-sector and whole-subnet payloads stay consistent
+
+    Percentages are computed against the sector's used count (the sum of all values in the
+    breakdown) and rounded to two decimals. Buckets are sorted by count descending, then by
+    public_id ascending as a tiebreak; the Unknown bucket is always emitted last so its
+    position is stable regardless of size
+
+    Precondition: every count value in ``breakdown`` is positive. ``_bucket_used_by_type``
+    upholds this by only inserting via ``cell[key] = cell.get(key, 0) + 1`` so the helper
+    short-circuits on ``used_count <= 0`` rather than guarding each division
+
+    Args:
+        breakdown (dict[int | None, int]): Per-cell {type_id_or_None: count} as produced by
+            _bucket_used_by_type for one cell
+        type_meta (dict[int, dict[str, Any]]): {type_id: {'label', 'ci_explorer_color'}} as
+            produced by _resolve_type_meta; type_ids absent from this mapping fall through to
+            the Unknown bucket
+
+    Returns:
+        list[dict[str, Any]]: One entry per known type bucket with keys public_id, label,
+            ci_explorer_color, count, percentage, followed by the Unknown bucket (only when
+            non-empty). Empty list when the cell has no assigned IPs
+    """
+    used_count: int = sum(breakdown.values())
+
+    if used_count <= 0:
+        return []
+
+    known_counts: dict[int, int] = {}
+    unknown_count: int = 0
+
+    for raw_key, count in breakdown.items():
+        if isinstance(raw_key, int) and raw_key in type_meta:
+            known_counts[raw_key] = known_counts.get(raw_key, 0) + count
+        else:
+            unknown_count += count
+
+    known_buckets: list[dict[str, Any]] = [
+        {
+            CmdbObjectKey.PUBLIC_ID: type_id,
+            IpamOverviewKey.LABEL: type_meta[type_id][IpamOverviewKey.LABEL],
+            IpamOverviewKey.CI_EXPLORER_COLOR: type_meta[type_id].get(IpamOverviewKey.CI_EXPLORER_COLOR),
+            IpamOverviewKey.COUNT: count,
+            IpamOverviewKey.PERCENTAGE: round((count / used_count) * 100, 2),
+        }
+        for type_id, count in known_counts.items()
+    ]
+
+    known_buckets.sort(key=lambda bucket: (-bucket[IpamOverviewKey.COUNT], bucket[CmdbObjectKey.PUBLIC_ID]))
+
+    if unknown_count > 0:
+        known_buckets.append({
+            CmdbObjectKey.PUBLIC_ID: None,
+            IpamOverviewKey.LABEL: IpamBucketLabel.UNKNOWN,
+            IpamOverviewKey.CI_EXPLORER_COLOR: None,
+            IpamOverviewKey.COUNT: unknown_count,
+            IpamOverviewKey.PERCENTAGE: round((unknown_count / used_count) * 100, 2),
+        })
+
+    return known_buckets
 
 
 def _compose_sector(
     first_ip_int: int,
     sector_size: int,
-    used_count: int,
+    breakdown: dict[int | None, int],
+    type_meta: dict[int, dict[str, Any]],
 ) -> dict[str, Any]:
     """
     Shapes one sector entry of the 'ip_distribution' grid
 
-    The percentage is the per-cell saturation ('used_count / sector_size * 100'), rounded to
-    two decimals; this matches the frontend's heatmap colouring convention. Position-implied
-    fields (sector index, sector size) are omitted: the consumer reads the index from the
-    sector's position in its parent range's 'sectors' array, and derives the size from
+    The sector's used_count is derived from the breakdown (sum of all per-type counts) so the
+    same source of truth feeds both the heatmap saturation and the per-type pie. ``percentage``
+    is the per-cell saturation ('used_count / sector_size * 100'), rounded to two decimals;
+    this matches the frontend's heatmap colouring convention. ``type_stats`` is the per-type
+    pie data delegated to _compose_sector_type_stats; it is always present (empty list when
+    the sector has no assigned IPs) so the FE never has to null-check. Position-implied fields
+    (sector index, sector size) are omitted: the consumer reads the index from the sector's
+    position in its parent range's 'sectors' array, and derives the size from
     ip_end - ip_start + 1
 
     Args:
         first_ip_int (int): Integer of the first address the sector covers
         sector_size (int): Number of addresses the sector covers (used only for the percentage
             denominator and to compute ip_end)
-        used_count (int): Number of assigned IPs inside the sector
+        breakdown (dict[int | None, int]): Per-cell {type_id_or_None: count} as produced by
+            _bucket_used_by_type for this cell
+        type_meta (dict[int, dict[str, Any]]): {type_id: {'label', 'ci_explorer_color'}} as
+            produced by _resolve_type_meta
 
     Returns:
-        dict[str, Any]: Sector entry with ip_start, ip_end, used_count, percentage
+        dict[str, Any]: Sector entry with ip_start, ip_end, used_count, percentage, type_stats
     """
+    used_count: int = sum(breakdown.values())
+
     return {
         IpamOverviewKey.IP_START: str(IPv4Address(first_ip_int)),
         IpamOverviewKey.IP_END: str(IPv4Address(first_ip_int + sector_size - 1)),
         IpamOverviewKey.USED_COUNT: used_count,
         IpamOverviewKey.PERCENTAGE: round((used_count / sector_size) * 100, 2),
+        IpamOverviewKey.TYPE_STATS: _compose_sector_type_stats(breakdown, type_meta),
     }
 
 
 def _build_ip_distribution(
     network: IPv4Network | None,
     assigned: dict[str, dict[str, Any]],
+    type_meta: dict[int, dict[str, Any]],
 ) -> dict[str, Any]:
     """
     Builds the 'IP-Verteilung' grid payload for one subnet, or an empty dict when no grid is rendered
@@ -925,8 +1022,8 @@ def _build_ip_distribution(
     grid would have fewer cells; in that case (and when the CIDR is missing or unparsable) the
     function returns an empty dict so the frontend can omit the visualisation entirely. When
     rendered, every cell covers an equal slice of the subnet (network + broadcast included)
-    and carries the count of assigned IPs plus a per-cell saturation percentage that drives
-    the heatmap colouring
+    and carries the count of assigned IPs, a per-cell saturation percentage that drives the
+    heatmap colouring, and a per-type breakdown of the assigned IPs inside the cell
 
     The returned structure is intentionally minimal: position-implied fields (range index,
     sector index, sector size, top-level grid dimensions) are omitted because the grid
@@ -937,15 +1034,18 @@ def _build_ip_distribution(
         network (IPv4Network | None): The parsed subnet network, or None when the subnet's
             CIDR is missing or unparsable
         assigned (dict[str, dict[str, Any]]): {ip_str: row_info} as produced by
-            _load_assigned_rows_map; only used to bucket-count, the row metadata is ignored
-            here
+            _load_assigned_rows_map; both the bucket counts and the per-cell type_stats are
+            derived from it
+        type_meta (dict[int, dict[str, Any]]): {type_id: {'label', 'ci_explorer_color'}} as
+            produced by _resolve_type_meta; used to label per-cell type buckets and to decide
+            which type_ids fall through to Unknown
 
     Returns:
         dict[str, Any]: {'sector_size': N, 'ranges': [...]} when the subnet qualifies for the
             full grid, where 'sector_size' is the number of addresses each cell covers (same
             for every cell since the grid is uniform) and each range carries ip_start, ip_end,
-            and a nested 'sectors' list of cells with ip_start, ip_end, used_count,
-            percentage. Empty dict ({}) otherwise
+            and a nested 'sectors' list of cells with ip_start, ip_end, used_count, percentage,
+            type_stats. Empty dict ({}) otherwise
     """
     if network is None:
         return {}
@@ -960,7 +1060,9 @@ def _build_ip_distribution(
     if total_cells < max_grid_cells:
         return {}
 
-    counts: list[int] = _bucket_used_counts(assigned, network, sector_size, total_cells)
+    breakdowns: list[dict[int | None, int]] = _bucket_used_by_type(
+        assigned, network, sector_size, total_cells,
+    )
 
     base_int: int = int(network.network_address)
     range_span: int = sectors_per_range * sector_size
@@ -977,7 +1079,8 @@ def _build_ip_distribution(
             sectors.append(_compose_sector(
                 sector_first_int,
                 sector_size,
-                counts[global_cell],
+                breakdowns[global_cell],
+                type_meta,
             ))
 
         ranges.append({
@@ -1395,7 +1498,13 @@ def build_subnet_overview(
             whole subnet (not just the current page) and includes 'Unknown' (when present)
             and 'Free' buckets after the type buckets, 'ip_distribution' is the
             IP-Verteilung heatmap grid covering the full address space (network + broadcast
-            included). The grid is emitted only at its full 4 x 16 size (/26 and shorter
+            included). Each sector inside ip_distribution carries ip_start, ip_end,
+            used_count, percentage, type_stats; 'type_stats' is the per-type breakdown of the
+            sector's assigned IPs, shaped as a list of {public_id, label, ci_explorer_color,
+            count, percentage} entries with percentage computed against the sector's
+            used_count, and an Unknown bucket (public_id=None, ci_explorer_color=None)
+            appended last whenever the sector holds rows whose owning type cannot be
+            resolved. The grid is emitted only at its full 4 x 16 size (/26 and shorter
             prefixes); for /27 and narrower, or when the CIDR is unparsable, ip_distribution
             is an empty dict. 'ips.total' equals 'assignable_ips' under no search and no
             sort (lazy path), or the candidate-list length otherwise. 'vlans' lists every
@@ -1440,7 +1549,7 @@ def build_subnet_overview(
             assigned, type_meta, objects_manager,
         ),
         IpamOverviewKey.TYPE_DISTRIBUTION: _build_type_distribution(assigned, type_meta, assignable),
-        IpamOverviewKey.IP_DISTRIBUTION: _build_ip_distribution(network, assigned),
+        IpamOverviewKey.IP_DISTRIBUTION: _build_ip_distribution(network, assigned, type_meta),
         IpamOverviewKey.VLANS: load_vlans_by_subnets(
             objects_manager, types_manager, [public_id],
         ).get(public_id, []),
@@ -1532,7 +1641,7 @@ def build_invalid_subnet_overview(
             assigned, type_meta, objects_manager,
         ),
         IpamOverviewKey.TYPE_DISTRIBUTION: _build_type_distribution(assigned, type_meta, assignable),
-        IpamOverviewKey.IP_DISTRIBUTION: _build_ip_distribution(network, assigned),
+        IpamOverviewKey.IP_DISTRIBUTION: _build_ip_distribution(network, assigned, type_meta),
         IpamOverviewKey.VLANS: load_vlans_by_subnets(
             objects_manager, types_manager, [public_id],
         ).get(public_id, []),

--- a/cmdb/models/special_type_model/ipam_constants.py
+++ b/cmdb/models/special_type_model/ipam_constants.py
@@ -258,6 +258,7 @@ class IpamOverviewKey(BaseStrEnum):
     IP_START = 'ip_start'
     IP_END = 'ip_end'
     USED_COUNT = 'used_count'
+    TYPE_STATS = 'type_stats'
 
 
 class IpamRowStatus(BaseStrEnum):

--- a/tests/unit/framework/ipam/test_interface_validator.py
+++ b/tests/unit/framework/ipam/test_interface_validator.py
@@ -45,6 +45,7 @@ from cmdb.framework.ipam.interface_validator import (
     _collect_collision_errors,
     _row_matches,
     find_intra_submission_duplicates,
+    find_subnet_without_ip,
 )
 # -------------------------------------------------------------------------------------------------------------------- #
 
@@ -371,3 +372,90 @@ def test_find_intra_submission_duplicates_treats_different_subnets_as_distinct()
 def test_find_intra_submission_duplicates_returns_empty_for_empty_input() -> None:
     """No rows submitted means no errors"""
     assert find_intra_submission_duplicates([]) == []
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                           find_subnet_without_ip                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_find_subnet_without_ip_returns_empty_for_empty_input() -> None:
+    """No rows submitted means no errors"""
+    assert find_subnet_without_ip([]) == []
+
+
+def test_find_subnet_without_ip_accepts_complete_row() -> None:
+    """A row with both subnet_ref and ip set produces no error"""
+    rows = [(0, 1, '10.0.0.1')]
+
+    assert find_subnet_without_ip(rows) == []
+
+
+def test_find_subnet_without_ip_accepts_empty_placeholder_row() -> None:
+    """A row with neither subnet_ref nor ip set is treated as an empty placeholder and accepted"""
+    rows = [(0, None, None)]
+
+    assert find_subnet_without_ip(rows) == []
+
+
+def test_find_subnet_without_ip_accepts_ip_only_row_per_literal_scope() -> None:
+    """A row with ip set but no subnet is allowed (inverse case is not in scope)"""
+    rows = [(0, None, '10.0.0.1')]
+
+    assert find_subnet_without_ip(rows) == []
+
+
+def test_find_subnet_without_ip_flags_row_with_subnet_but_no_ip() -> None:
+    """A row with subnet_ref set and ip None produces one SUBNET_WITHOUT_IP error"""
+    rows = [(3, 42, None)]
+
+    errors = find_subnet_without_ip(rows)
+
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.SUBNET_WITHOUT_IP
+    details = errors[0][ValidationErrorKey.DETAILS]
+    assert details[IpamValidationDetailKey.ROW_INDEX] == 3
+    assert details[IpamValidationDetailKey.SUBNET_OBJECT_ID] == 42
+
+
+def test_find_subnet_without_ip_flags_multiple_offending_rows_in_order() -> None:
+    """Each offending row produces its own error; emission order matches input order"""
+    rows = [
+        (0, 1, None),
+        (1, 1, '10.0.0.1'),
+        (2, 2, None),
+    ]
+
+    errors = find_subnet_without_ip(rows)
+
+    assert len(errors) == 2
+    reported_rows = [err[ValidationErrorKey.DETAILS][IpamValidationDetailKey.ROW_INDEX] for err in errors]
+    assert reported_rows == [0, 2]
+
+
+def test_find_subnet_without_ip_flags_only_offending_rows_in_mixed_batch() -> None:
+    """A mixed batch produces errors only for the subnet-without-ip rows, leaving valid + empty rows alone"""
+    rows = [
+        (0, 1, '10.0.0.1'),  # valid
+        (1, None, None),     # empty placeholder
+        (2, 2, None),        # offending
+        (3, None, '10.0.0.2'),  # ip-only, literal-scope passes
+    ]
+
+    errors = find_subnet_without_ip(rows)
+
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.DETAILS][IpamValidationDetailKey.ROW_INDEX] == 2
+
+
+def test_find_subnet_without_ip_error_envelope_carries_code_message_and_details() -> None:
+    """The structured error envelope exposes code + a non-empty message + the documented detail keys"""
+    rows = [(7, 99, None)]
+
+    error = find_subnet_without_ip(rows)[0]
+
+    assert error[ValidationErrorKey.CODE] == InterfaceErrorCode.SUBNET_WITHOUT_IP
+    assert isinstance(error[ValidationErrorKey.MESSAGE], str)
+    assert error[ValidationErrorKey.MESSAGE]  # non-empty
+    assert set(error[ValidationErrorKey.DETAILS].keys()) == {
+        IpamValidationDetailKey.ROW_INDEX,
+        IpamValidationDetailKey.SUBNET_OBJECT_ID,
+    }

--- a/tests/unit/framework/ipam/test_subnet_overview.py
+++ b/tests/unit/framework/ipam/test_subnet_overview.py
@@ -54,7 +54,7 @@ from cmdb.framework.ipam.subnet_overview import (
     _AssignedField,
     _apply_candidate_filter,
     _build_broken_state_payload,
-    _bucket_used_counts,
+    _bucket_used_by_type,
     _build_ip_distribution,
     _build_ips_block,
     _build_type_distribution,
@@ -62,6 +62,7 @@ from cmdb.framework.ipam.subnet_overview import (
     _compose_free_row,
     _compose_ip_row,
     _compose_sector,
+    _compose_sector_type_stats,
     _compute_grid_dimensions,
     _compute_sort_key,
     _extract_row_fields,
@@ -1078,78 +1079,271 @@ def test_compute_grid_dimensions_shrinks_to_one_by_one_for_single_address() -> N
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
-#                                            _bucket_used_counts                                                       #
+#                                            _bucket_used_by_type                                                      #
 # -------------------------------------------------------------------------------------------------------------------- #
-def test_bucket_used_counts_returns_zero_filled_list_for_empty_assigned_map() -> None:
-    """An empty assigned map produces a counts list of the requested length with all zeros"""
-    counts = _bucket_used_counts({}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+def test_bucket_used_by_type_returns_empty_breakdowns_for_empty_assigned_map() -> None:
+    """An empty assigned map produces a list of empty breakdowns of the requested length"""
+    breakdowns = _bucket_used_by_type({}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
 
-    assert counts == [0] * 64
-
-
-def test_bucket_used_counts_returns_empty_list_when_total_cells_is_zero() -> None:
-    """No cells → no counts (guard against division by zero downstream)"""
-    counts = _bucket_used_counts({'10.0.0.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=0)
-
-    assert counts == []
+    assert breakdowns == [{}] * 64
 
 
-def test_bucket_used_counts_short_circuits_when_sector_size_is_zero() -> None:
-    """Zero sector_size cannot index any cell; the helper returns the zero-filled list without raising"""
-    counts = _bucket_used_counts({'10.0.0.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=0, total_cells=4)
+def test_bucket_used_by_type_returns_empty_list_when_total_cells_is_zero() -> None:
+    """No cells → no breakdowns (guard against division by zero downstream)"""
+    breakdowns = _bucket_used_by_type(
+        {'10.0.0.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=0,
+    )
 
-    assert counts == [0, 0, 0, 0]
+    assert breakdowns == []
 
 
-def test_bucket_used_counts_increments_correct_cell_for_assigned_ip() -> None:
+def test_bucket_used_by_type_short_circuits_when_sector_size_is_zero() -> None:
+    """Zero sector_size cannot index any cell; the helper returns empty breakdowns without raising"""
+    breakdowns = _bucket_used_by_type(
+        {'10.0.0.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=0, total_cells=4,
+    )
+
+    assert breakdowns == [{}, {}, {}, {}]
+
+
+def test_bucket_used_by_type_increments_correct_cell_for_assigned_ip() -> None:
     """An IP at offset 5 with sector_size=4 lands in cell index 1 (5 // 4)"""
-    counts = _bucket_used_counts({'10.0.0.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+    breakdowns = _bucket_used_by_type(
+        {'10.0.0.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64,
+    )
 
-    assert counts[1] == 1
-    assert sum(counts) == 1
+    assert breakdowns[1] == {None: 1}
+    assert sum(sum(b.values()) for b in breakdowns) == 1
 
 
-def test_bucket_used_counts_skips_ip_outside_the_subnet() -> None:
+def test_bucket_used_by_type_skips_ip_outside_the_subnet() -> None:
     """IPs whose offset falls outside the network's span are ignored"""
-    counts = _bucket_used_counts({'192.168.1.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+    breakdowns = _bucket_used_by_type(
+        {'192.168.1.5': {}}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64,
+    )
 
-    assert sum(counts) == 0
+    assert sum(sum(b.values()) for b in breakdowns) == 0
 
 
-def test_bucket_used_counts_skips_unparseable_ip_string() -> None:
+def test_bucket_used_by_type_skips_unparseable_ip_string() -> None:
     """An ip_str that parse_ipv4 cannot parse is skipped without raising"""
-    counts = _bucket_used_counts(
+    breakdowns = _bucket_used_by_type(
         {'not-an-ip': {}}, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64,
     )
 
-    assert sum(counts) == 0
+    assert sum(sum(b.values()) for b in breakdowns) == 0
 
 
-def test_bucket_used_counts_distributes_multiple_assigned_ips_across_cells() -> None:
+def test_bucket_used_by_type_distributes_multiple_assigned_ips_across_cells() -> None:
     """Multiple IPs land in distinct cells when their offsets are in different sector_size groups"""
     assigned = {'10.0.0.1': {}, '10.0.0.5': {}, '10.0.0.9': {}}
 
-    counts = _bucket_used_counts(assigned, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+    breakdowns = _bucket_used_by_type(assigned, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
 
-    assert counts[0] == 1
-    assert counts[1] == 1
-    assert counts[2] == 1
+    assert breakdowns[0] == {None: 1}
+    assert breakdowns[1] == {None: 1}
+    assert breakdowns[2] == {None: 1}
+
+
+def test_bucket_used_by_type_uses_int_type_id_as_bucket_key() -> None:
+    """A row with an int type_id lands under that int key in the owning cell's breakdown"""
+    assigned = {'10.0.0.5': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None)}
+
+    breakdowns = _bucket_used_by_type(assigned, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+
+    assert breakdowns[1] == {OWNER_TYPE_ID: 1}
+
+
+def test_bucket_used_by_type_routes_non_int_type_id_to_none_key() -> None:
+    """A non-int type_id (e.g. string) is bucketed under None, not its raw value"""
+    assigned = {'10.0.0.5': _make_assigned_entry(OWNER_OBJECT_ID, '50', None)}
+
+    breakdowns = _bucket_used_by_type(assigned, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+
+    assert breakdowns[1] == {None: 1}
+
+
+def test_bucket_used_by_type_coalesces_same_type_ips_in_same_cell() -> None:
+    """Multiple IPs of the same type in one cell sum into a single bucket"""
+    assigned = {
+        '10.0.0.4': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None),
+        '10.0.0.5': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None),
+        '10.0.0.6': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None),
+    }
+
+    breakdowns = _bucket_used_by_type(assigned, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+
+    assert breakdowns[1] == {OWNER_TYPE_ID: 3}
+
+
+def test_bucket_used_by_type_keeps_distinct_types_in_same_cell_separate() -> None:
+    """Two different types in one cell produce two keys with their respective counts"""
+    assigned = {
+        '10.0.0.4': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None),
+        '10.0.0.5': _make_assigned_entry(OWNER_OBJECT_ID + 1, OTHER_OWNER_TYPE_ID, None),
+        '10.0.0.6': _make_assigned_entry(OWNER_OBJECT_ID + 2, OTHER_OWNER_TYPE_ID, None),
+    }
+
+    breakdowns = _bucket_used_by_type(assigned, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64)
+
+    assert breakdowns[1] == {OWNER_TYPE_ID: 1, OTHER_OWNER_TYPE_ID: 2}
+
+
+def test_bucket_used_by_type_rejects_ip_exactly_at_span_boundary() -> None:
+    """An IP at offset == total_cells * sector_size is outside the grid and is skipped"""
+    # network 10.0.0.0/24 has 256 addresses; with sector_size=4 and total_cells=64 the span is 256.
+    # 10.0.1.0 has offset 256, which must be rejected (>= span).
+    assigned = {'10.0.1.0': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None)}
+
+    breakdowns = _bucket_used_by_type(
+        assigned, IPv4Network('10.0.0.0/24'), sector_size=4, total_cells=64,
+    )
+
+    assert sum(sum(b.values()) for b in breakdowns) == 0
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                         _compose_sector_type_stats                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_compose_sector_type_stats_returns_empty_list_for_empty_breakdown() -> None:
+    """An empty breakdown (used_count == 0) → empty type_stats list"""
+    assert _compose_sector_type_stats({}, {}) == []
+
+
+def test_compose_sector_type_stats_emits_single_known_bucket_at_full_percentage() -> None:
+    """One known type covering the whole used count → one bucket at 100%"""
+    type_meta = {OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: '#FF0000'}}
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 4}, type_meta)
+
+    assert stats == [
+        {
+            CmdbObjectKey.PUBLIC_ID: OWNER_TYPE_ID,
+            IpamOverviewKey.LABEL: 'Server',
+            IpamOverviewKey.CI_EXPLORER_COLOR: '#FF0000',
+            IpamOverviewKey.COUNT: 4,
+            IpamOverviewKey.PERCENTAGE: 100.0,
+        },
+    ]
+
+
+def test_compose_sector_type_stats_sorts_known_buckets_by_count_descending() -> None:
+    """Known buckets are ordered count desc (dominant type first)"""
+    type_meta = {
+        OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: None},
+        OTHER_OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Printer', IpamOverviewKey.CI_EXPLORER_COLOR: None},
+    }
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 1, OTHER_OWNER_TYPE_ID: 3}, type_meta)
+
+    labels = [bucket[IpamOverviewKey.LABEL] for bucket in stats]
+    assert labels == ['Printer', 'Server']
+
+
+def test_compose_sector_type_stats_breaks_count_ties_by_public_id_ascending() -> None:
+    """When counts tie, the smaller public_id comes first"""
+    type_meta = {
+        OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: None},
+        OTHER_OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Printer', IpamOverviewKey.CI_EXPLORER_COLOR: None},
+    }
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 2, OTHER_OWNER_TYPE_ID: 2}, type_meta)
+
+    public_ids = [bucket[CmdbObjectKey.PUBLIC_ID] for bucket in stats]
+    assert public_ids == [OWNER_TYPE_ID, OTHER_OWNER_TYPE_ID]
+
+
+def test_compose_sector_type_stats_emits_unknown_bucket_last_even_when_largest() -> None:
+    """The Unknown bucket is appended last regardless of how large its count is"""
+    type_meta = {OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: None}}
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 1, None: 9}, type_meta)
+
+    labels = [bucket[IpamOverviewKey.LABEL] for bucket in stats]
+    assert labels == ['Server', IpamBucketLabel.UNKNOWN]
+
+
+def test_compose_sector_type_stats_routes_orphaned_int_type_id_to_unknown() -> None:
+    """An int type_id not present in type_meta is folded into the Unknown bucket"""
+    type_meta = {OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: None}}
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 1, 9_999: 2}, type_meta)
+
+    unknown = next(b for b in stats if b[IpamOverviewKey.LABEL] == IpamBucketLabel.UNKNOWN)
+    assert unknown[CmdbObjectKey.PUBLIC_ID] is None
+    assert unknown[IpamOverviewKey.COUNT] == 2
+
+
+def test_compose_sector_type_stats_routes_none_key_to_unknown() -> None:
+    """A None key in the breakdown is folded into the Unknown bucket"""
+    stats = _compose_sector_type_stats({None: 3}, type_meta={})
+
+    assert stats == [
+        {
+            CmdbObjectKey.PUBLIC_ID: None,
+            IpamOverviewKey.LABEL: IpamBucketLabel.UNKNOWN,
+            IpamOverviewKey.CI_EXPLORER_COLOR: None,
+            IpamOverviewKey.COUNT: 3,
+            IpamOverviewKey.PERCENTAGE: 100.0,
+        },
+    ]
+
+
+def test_compose_sector_type_stats_unknown_sums_orphans_and_none_keys() -> None:
+    """Unknown.count is the sum of None-keyed rows and unresolvable int type_ids"""
+    type_meta = {OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: None}}
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 1, None: 2, 9_999: 3}, type_meta)
+
+    unknown = next(b for b in stats if b[IpamOverviewKey.LABEL] == IpamBucketLabel.UNKNOWN)
+    assert unknown[IpamOverviewKey.COUNT] == 5
+
+
+def test_compose_sector_type_stats_rounds_percentages_to_two_decimals() -> None:
+    """Percentages are computed against used_count and rounded to 2 decimals (1/3, 2/3 → 33.33, 66.67)"""
+    type_meta = {
+        OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: None},
+        OTHER_OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Printer', IpamOverviewKey.CI_EXPLORER_COLOR: None},
+    }
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 1, OTHER_OWNER_TYPE_ID: 2}, type_meta)
+
+    by_label = {bucket[IpamOverviewKey.LABEL]: bucket[IpamOverviewKey.PERCENTAGE] for bucket in stats}
+    assert by_label == {'Server': 33.33, 'Printer': 66.67}
+
+
+def test_compose_sector_type_stats_emits_none_color_when_type_meta_omits_it() -> None:
+    """A type_meta entry without ci_explorer_color yields None on the bucket, not a KeyError"""
+    type_meta = {OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server'}}
+
+    stats = _compose_sector_type_stats({OWNER_TYPE_ID: 1}, type_meta)
+
+    assert stats[0][IpamOverviewKey.CI_EXPLORER_COLOR] is None
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
 #                                              _compose_sector                                                         #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_compose_sector_emits_full_shape_and_rounds_percentage_to_two_decimals() -> None:
-    """Output pins ip_start/ip_end/used_count/percentage; percentage rounded to 2 decimals"""
+    """Output pins ip_start/ip_end/used_count/percentage/type_stats; percentage rounded to 2 decimals"""
     first_int = int(IPv4Address('10.0.0.0'))
 
-    sector = _compose_sector(first_int, sector_size=4, used_count=1)
+    sector = _compose_sector(first_int, sector_size=4, breakdown={None: 1}, type_meta={})
 
     assert sector == {
         IpamOverviewKey.IP_START: '10.0.0.0',
         IpamOverviewKey.IP_END: '10.0.0.3',
         IpamOverviewKey.USED_COUNT: 1,
         IpamOverviewKey.PERCENTAGE: 25.0,
+        IpamOverviewKey.TYPE_STATS: [
+            {
+                CmdbObjectKey.PUBLIC_ID: None,
+                IpamOverviewKey.LABEL: IpamBucketLabel.UNKNOWN,
+                IpamOverviewKey.CI_EXPLORER_COLOR: None,
+                IpamOverviewKey.COUNT: 1,
+                IpamOverviewKey.PERCENTAGE: 100.0,
+            },
+        ],
     }
 
 
@@ -1158,17 +1352,17 @@ def test_compose_sector_emits_full_shape_and_rounds_percentage_to_two_decimals()
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_build_ip_distribution_returns_empty_dict_when_network_is_none() -> None:
     """A missing/unparsable subnet network → grid suppressed (empty dict)"""
-    assert _build_ip_distribution(None, {}) == {}
+    assert _build_ip_distribution(None, {}, {}) == {}
 
 
 def test_build_ip_distribution_returns_empty_dict_when_subnet_too_small_for_full_grid() -> None:
     """/27 (32 addresses → 4×8 cells) is below the full 4×16 = 64-cell cap and is suppressed"""
-    assert _build_ip_distribution(IPv4Network('10.0.0.0/27'), {}) == {}
+    assert _build_ip_distribution(IPv4Network('10.0.0.0/27'), {}, {}) == {}
 
 
 def test_build_ip_distribution_emits_full_grid_for_slash_24() -> None:
     """A /24 yields the full grid: sector_size=4, 4 ranges, each with 16 sectors"""
-    grid = _build_ip_distribution(IPv4Network('10.0.0.0/24'), {})
+    grid = _build_ip_distribution(IPv4Network('10.0.0.0/24'), {}, {})
 
     assert grid[IpamOverviewKey.SECTOR_SIZE] == 4
     assert len(grid[IpamOverviewKey.RANGES]) == 4
@@ -1180,7 +1374,7 @@ def test_build_ip_distribution_reflects_assigned_counts_in_correct_cells() -> No
     """An assigned IP appears in its sector's used_count and not in others"""
     assigned: dict[str, dict[str, Any]] = {'10.0.0.5': {}}
 
-    grid = _build_ip_distribution(IPv4Network('10.0.0.0/24'), assigned)
+    grid = _build_ip_distribution(IPv4Network('10.0.0.0/24'), assigned, {})
 
     # Sector index 1 of range 0 covers 10.0.0.4-10.0.0.7
     first_range = grid[IpamOverviewKey.RANGES][0]


### PR DESCRIPTION
Changes:
* added additional information to ip distribution in subnet overview
* enforced that IPAM interface needs an ip address when a subnet is selected