### PR TITLE
DAT-2688-ipam-tree

### DIFF
--- a/cmdb/framework/ipam/__init__.py
+++ b/cmdb/framework/ipam/__init__.py
@@ -19,7 +19,7 @@ IP Address Management (IPAM) feature for DataGerry
 Provides the validators, overview builders, and shared CIDR helpers behind the IPAM
 SpecialTypes (SUPERNET, SUBNET, VLAN) and the dg-ipam-interface MDS section template.
 Modules:
-  - cidr: pure IPv4 helpers (parsing, containment, address-count policy)
+  - cidr: pure IPv4 / IPv6 helpers (parsing, containment, address-count policy)
   - pagination: page/page_size clamping shared by the overview routes
   - references: SpecialType id resolution
   - search: search-input normalization helpers shared by the overview routes
@@ -27,6 +27,10 @@ Modules:
       validation invoked at save time and from the inline pre-validation REST routes
   - enforcement: cross-row enforcement helpers used by the validator orchestrators
   - subnet_overview / supernet_overview: payload builders for the IPAM overview views
+  - tree_overview: payload builders for the IPAM sidebar tree (flat supernet / unassigned
+      blocks plus the per-supernet CIDR-nested subnet subtree)
+  - subnet_options: paginated, family-filterable subnet list backing the dg-ipam-interface
+      subnet picker
   - supernet_membership: write-side mutations against the SUBNET <-> SUPERNET relation
       (currently the batch 'unassign subnets from supernet' flow used by the overview)
   - special_type_wiring: cross-wires the SpecialType reference fields (Subnet -> Supernet,

--- a/cmdb/framework/ipam/cidr.py
+++ b/cmdb/framework/ipam/cidr.py
@@ -171,6 +171,23 @@ def network_family(network: Network) -> str:
     return IpAddressFamily.IPV6 if network.version == IpVersion.V6 else IpAddressFamily.IPV4
 
 
+def address_family(address: Address) -> str:
+    """
+    Returns the address-family token of a parsed host address as an IpAddressFamily value
+
+    Address counterpart of ``network_family``: maps a parsed IP to the same 'ipv4' / 'ipv6'
+    tokens the IPAM selectors use, so per-row family-consistency checks (e.g. the interface
+    row's 'dg-interface-type' against its IP) agree with the network-level mapping
+
+    Args:
+        address (Address): The parsed host address
+
+    Returns:
+        str: IpAddressFamily.IPV6 for an IPv6 address, IpAddressFamily.IPV4 otherwise
+    """
+    return IpAddressFamily.IPV6 if address.version == IpVersion.V6 else IpAddressFamily.IPV4
+
+
 def contains(parent: Network, child: Network) -> bool:
     """
     Reports whether 'child' is a subnet of (or equal to) 'parent'

--- a/cmdb/framework/ipam/enforcement.py
+++ b/cmdb/framework/ipam/enforcement.py
@@ -299,17 +299,24 @@ def _enforce_vlan_object(
 # -------------------------------------------------------------------------------------------------------------------- #
 #                                          INTERFACE ROW ENFORCEMENT                                                   #
 # -------------------------------------------------------------------------------------------------------------------- #
-def _extract_interface_rows(candidate_object: dict[str, Any]) -> list[tuple[int, int | None, str | None]]:
+def _extract_interface_rows(
+    candidate_object: dict[str, Any],
+) -> list[tuple[int, int | None, str | None, str | None]]:
     """
     Walks the candidate's dg-ipam-interface MDS rows and returns one tuple per row
+
+    The interface-type token ('dg-interface-type') is passed through as-is when it is a
+    non-empty string and None otherwise; legacy rows without the selector therefore skip the
+    type-family consistency check downstream
 
     Args:
         candidate_object (dict[str, Any]): The about-to-be-saved CmdbObject document
 
     Returns:
-        list[tuple[int, int | None, str | None]]: (row_index, subnet_ref, ip_address) tuples
+        list[tuple[int, int | None, str | None, str | None]]: (row_index, subnet_ref,
+            ip_address, interface_type) tuples
     """
-    rows_out: list[tuple[int, int | None, str | None]] = []
+    rows_out: list[tuple[int, int | None, str | None, str | None]] = []
 
     for section in candidate_object.get(CmdbObjectKey.MULTI_DATA_SECTIONS, []) or []:
         if section.get(CmdbObjectMdsKey.SECTION_ID) != IpamSection.INTERFACE:
@@ -318,6 +325,7 @@ def _extract_interface_rows(candidate_object: dict[str, Any]) -> list[tuple[int,
         for row_index, row in enumerate(section.get(CmdbObjectMdsKey.VALUES, []) or []):
             subnet_ref: int | None = None
             ip_address: str | None = None
+            interface_type: str | None = None
 
             for entry in row.get(CmdbObjectMdsRowKey.DATA, []) or []:
                 name: Any = entry.get(CmdbObjectFieldKey.NAME)
@@ -327,8 +335,10 @@ def _extract_interface_rows(candidate_object: dict[str, Any]) -> list[tuple[int,
                     subnet_ref = _coerce_int(value)
                 elif name == InterfaceField.IP:
                     ip_address = value if isinstance(value, str) and value else None
+                elif name == InterfaceField.TYPE:
+                    interface_type = value if isinstance(value, str) and value else None
 
-            rows_out.append((row_index, subnet_ref, ip_address))
+            rows_out.append((row_index, subnet_ref, ip_address, interface_type))
 
     return rows_out
 
@@ -352,7 +362,7 @@ def _enforce_interface_rows(
     Returns:
         list[dict[str, Any]]: Accumulated structured errors; empty when all rows are valid
     """
-    rows: list[tuple[int, int | None, str | None]] = _extract_interface_rows(candidate_object)
+    rows: list[tuple[int, int | None, str | None, str | None]] = _extract_interface_rows(candidate_object)
 
     if not rows:
         return []

--- a/cmdb/framework/ipam/interface_validator.py
+++ b/cmdb/framework/ipam/interface_validator.py
@@ -38,10 +38,12 @@ from cmdb.models.special_type_model.ipam_constants import (
     IpamSection,
     IpamValidationDetailKey,
 )
-from cmdb.utils import BaseStrEnum, build_error
+from cmdb.utils import BaseStrEnum, ValidationErrorKey, build_error
 from cmdb.framework.ipam.cidr import (
     Network,
     Address,
+    address_family,
+    network_family,
     parse_cidr,
     parse_ip,
     ip_in_network,
@@ -64,6 +66,7 @@ class InterfaceErrorCode(BaseStrEnum):
     IP_NOT_IN_SUBNET = 'ip_not_in_subnet'
     IP_RESERVED = 'ip_reserved'
     IP_DUPLICATE = 'ip_duplicate'
+    TYPE_FAMILY_MISMATCH = 'type_family_mismatch'
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -167,8 +170,8 @@ def _check_ip_membership(ip: Address, subnet_net: Network) -> list[dict[str, Any
     Validates that the IP sits inside the subnet and is neither the network nor broadcast address
 
     Args:
-        ip (IPv4Address): The parsed candidate IP
-        subnet_net (IPv4Network): The subnet's parsed network
+        ip (Address): The parsed candidate IP (IPv4 or IPv6)
+        subnet_net (Network): The subnet's parsed network (IPv4 or IPv6)
 
     Returns:
         list[dict[str, Any]]: Errors found, empty when membership is valid
@@ -394,17 +397,19 @@ def validate_interface(
 
 
 def find_intra_submission_duplicates(
-    rows: list[tuple[int, int | None, str | None]],
+    rows: list[tuple[int, int | None, str | None, str | None]],
 ) -> list[dict[str, Any]]:
     """
     Reports interface rows in the same submission that share both subnet ref and IP
 
     Rows missing either the subnet ref or the IP are skipped (treated as incomplete, surfaced
-    by the per-row check instead). The first occurrence of a (subnet_ref, ip) pair seeds the
-    seen-set; every subsequent matching row is reported as a duplicate against that first row
+    by the per-row check instead); the row's interface-type token plays no role here. The
+    first occurrence of a (subnet_ref, ip) pair seeds the seen-set; every subsequent matching
+    row is reported as a duplicate against that first row
 
     Args:
-        rows (list[tuple[int, int | None, str | None]]): (row_index, subnet_ref, ip) tuples
+        rows (list[tuple[int, int | None, str | None, str | None]]): (row_index, subnet_ref,
+            ip, interface_type) tuples
 
     Returns:
         list[dict[str, Any]]: One IP_DUPLICATE error per duplicate occurrence, with details
@@ -413,7 +418,7 @@ def find_intra_submission_duplicates(
     seen: dict[tuple[int, str], int] = {}
     errors: list[dict[str, Any]] = []
 
-    for row_index, subnet_ref, ip in rows:
+    for row_index, subnet_ref, ip, _ in rows:
         if subnet_ref is None or ip is None:
             continue
 
@@ -439,7 +444,7 @@ def find_intra_submission_duplicates(
 
 
 def find_subnet_without_ip(
-    rows: list[tuple[int, int | None, str | None]],
+    rows: list[tuple[int, int | None, str | None, str | None]],
 ) -> list[dict[str, Any]]:
     """
     Reports interface rows that have a subnet reference selected but no IP address
@@ -449,11 +454,12 @@ def find_subnet_without_ip(
     uniqueness, and would not contribute to any subnet's used-IP roll-up. The inverse case (IP
     without subnet) is intentionally not flagged here - that is the literal request scope, and
     a row with neither field set is treated as a still-empty placeholder row, accepted silently
-    by every caller of this batch validator
+    by every caller of this batch validator. The row's interface-type token plays no role here
 
     Args:
-        rows (list[tuple[int, int | None, str | None]]): (row_index, subnet_ref, ip) tuples as
-            produced by _extract_interface_rows in cmdb.framework.ipam.enforcement
+        rows (list[tuple[int, int | None, str | None, str | None]]): (row_index, subnet_ref,
+            ip, interface_type) tuples as produced by _extract_interface_rows in
+            cmdb.framework.ipam.enforcement
 
     Returns:
         list[dict[str, Any]]: One SUBNET_WITHOUT_IP error per offending row, with details
@@ -461,7 +467,7 @@ def find_subnet_without_ip(
     """
     errors: list[dict[str, Any]] = []
 
-    for row_index, subnet_ref, ip in rows:
+    for row_index, subnet_ref, ip, _ in rows:
         if subnet_ref is None or ip is not None:
             continue
 
@@ -477,10 +483,187 @@ def find_subnet_without_ip(
     return errors
 
 
+def _load_subnets_by_ids(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    subnet_ids: list[int],
+) -> dict[int, dict[str, Any]]:
+    """
+    Loads the SUBNET CmdbObjects for the given public_ids in one query, keyed by public_id
+
+    Ids that match no SUBNET object are simply absent from the result - the per-row check
+    (``_load_subnet_object``) is responsible for reporting unknown subnet references, so this
+    batch loader stays silent about them. Returns an empty dict when no SUBNET CmdbType is
+    defined or the id list is empty
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        subnet_ids (list[int]): public_ids of the referenced subnets (deduplicated by caller)
+
+    Returns:
+        dict[int, dict[str, Any]]: {public_id: subnet document} for every id that resolved
+    """
+    if not subnet_ids:
+        return {}
+
+    subnet_type_id: int | None = resolve_special_type_id(types_manager, SpecialType.SUBNET)
+
+    if subnet_type_id is None:
+        return {}
+
+    matches: list[dict[str, Any]] = objects_manager.find_objects(
+        {CmdbObjectKey.PUBLIC_ID: {'$in': subnet_ids}, CmdbObjectKey.TYPE_ID: subnet_type_id},
+        as_dict=True,
+    )
+
+    return {m[CmdbObjectKey.PUBLIC_ID]: m for m in matches if CmdbObjectKey.PUBLIC_ID in m}
+
+
+def _check_row_type_against_ip(row_index: int, interface_type: str, ip_address: str) -> list[dict[str, Any]]:
+    """
+    Validates the row's interface-type token agrees with the address family of the row's IP
+
+    Skipped (no error) when the IP does not parse - an unparsable IP is reported as IP_INVALID
+    by the per-row check when the row is complete, and a half-typed IP should not produce
+    family noise on top. An unrecognised token (anything but the IpAddressFamily values) can
+    never equal the parsed family, so it is reported as a mismatch
+
+    Args:
+        row_index (int): Position of the row in the MDS section, echoed in the error details
+        interface_type (str): The row's 'dg-interface-type' token
+        ip_address (str): The row's IP address string
+
+    Returns:
+        list[dict[str, Any]]: A single-element error list on mismatch, empty when consistent
+            or when the IP is unparsable
+    """
+    parsed: Address | None = parse_ip(ip_address)
+
+    if parsed is None:
+        return []
+
+    ip_family: str = address_family(parsed)
+
+    if interface_type == ip_family:
+        return []
+
+    return [build_error(
+        InterfaceErrorCode.TYPE_FAMILY_MISMATCH,
+        f"Interface row {row_index}: type '{interface_type}' does not match the address family "
+        f"'{ip_family}' of IP {ip_address}",
+        {
+            IpamValidationDetailKey.ROW_INDEX: row_index,
+            IpamValidationDetailKey.INTERFACE_TYPE: interface_type,
+            IpamValidationDetailKey.IP_ADDRESS: ip_address,
+            IpamValidationDetailKey.IP_FAMILY: ip_family,
+        },
+    )]
+
+
+def _check_row_type_against_subnet(
+    row_index: int,
+    interface_type: str,
+    subnet_obj: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """
+    Validates the row's interface-type token agrees with the referenced subnet's CIDR family
+
+    Skipped (no error) when the subnet's 'dg-network-range' is missing or unparsable - that
+    degenerate state is reported as SUBNET_BROKEN_STATE by the per-row check when the row is
+    complete. An unrecognised token can never equal the parsed family, so it is reported as a
+    mismatch
+
+    Args:
+        row_index (int): Position of the row in the MDS section, echoed in the error details
+        interface_type (str): The row's 'dg-interface-type' token
+        subnet_obj (dict[str, Any]): The referenced SUBNET CmdbObject document
+
+    Returns:
+        list[dict[str, Any]]: A single-element error list on mismatch, empty when consistent
+            or when the subnet's CIDR is unparsable
+    """
+    raw_range: Any = extract_field_value(subnet_obj, SubnetField.NETWORK_RANGE)
+    network: Network | None = parse_cidr(raw_range) if isinstance(raw_range, str) else None
+
+    if network is None:
+        return []
+
+    subnet_fam: str = network_family(network)
+
+    if interface_type == subnet_fam:
+        return []
+
+    return [build_error(
+        InterfaceErrorCode.TYPE_FAMILY_MISMATCH,
+        f"Interface row {row_index}: type '{interface_type}' does not match the address family "
+        f"'{subnet_fam}' of subnet {network} (object {subnet_obj.get(CmdbObjectKey.PUBLIC_ID)})",
+        {
+            IpamValidationDetailKey.ROW_INDEX: row_index,
+            IpamValidationDetailKey.INTERFACE_TYPE: interface_type,
+            IpamValidationDetailKey.SUBNET_OBJECT_ID: subnet_obj.get(CmdbObjectKey.PUBLIC_ID),
+            IpamValidationDetailKey.SUBNET_RANGE: str(network),
+            IpamValidationDetailKey.SUBNET_FAMILY: subnet_fam,
+        },
+    )]
+
+
+def find_type_family_mismatches(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    rows: list[tuple[int, int | None, str | None, str | None]],
+) -> list[dict[str, Any]]:
+    """
+    Reports interface rows whose 'dg-interface-type' token contradicts the row's data
+
+    For every row carrying a type token, the token is checked against the address family of
+    the row's IP (when an IP is present) and against the CIDR family of the referenced subnet
+    (when a subnet ref is present), so a token can produce up to two mismatch errors per row.
+    Rows without a token are skipped entirely - legacy rows pre-date the selector, mirroring
+    the skip-when-missing policy of the subnet / supernet selectors. Unknown subnet refs,
+    unparsable IPs and unparsable subnet CIDRs are skipped here because the per-row check
+    reports those states under their own codes
+
+    The referenced subnets of all typed rows are loaded in one batch query, so the check adds
+    at most one DB round-trip regardless of row count
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        rows (list[tuple[int, int | None, str | None, str | None]]): (row_index, subnet_ref,
+            ip, interface_type) tuples
+
+    Returns:
+        list[dict[str, Any]]: One TYPE_FAMILY_MISMATCH error per contradiction found
+    """
+    typed_rows: list[tuple[int, int | None, str | None, str]] = [
+        (row_index, subnet_ref, ip, interface_type)
+        for row_index, subnet_ref, ip, interface_type in rows
+        if interface_type is not None
+    ]
+
+    if not typed_rows:
+        return []
+
+    subnet_ids: list[int] = sorted({subnet_ref for _, subnet_ref, _, _ in typed_rows if subnet_ref is not None})
+    subnets_by_id: dict[int, dict[str, Any]] = _load_subnets_by_ids(objects_manager, types_manager, subnet_ids)
+
+    errors: list[dict[str, Any]] = []
+
+    for row_index, subnet_ref, ip, interface_type in typed_rows:
+        if ip is not None:
+            errors.extend(_check_row_type_against_ip(row_index, interface_type, ip))
+
+        if subnet_ref is not None and subnet_ref in subnets_by_id:
+            errors.extend(_check_row_type_against_subnet(row_index, interface_type, subnets_by_id[subnet_ref]))
+
+    return errors
+
+
 def validate_interface_rows(
     objects_manager: ObjectsManager,
     types_manager: TypesManager,
-    rows: list[tuple[int, int | None, str | None]],
+    rows: list[tuple[int, int | None, str | None, str | None]],
     exclude_object_id: int | None = None,
 ) -> list[dict[str, Any]]:
     """
@@ -492,7 +675,10 @@ def validate_interface_rows(
          placeholder rows pass through silently
       2. Cross-row duplicate detection via find_intra_submission_duplicates so two rows on the
          same form sharing a (subnet, IP) pair are flagged before they hit the DB
-      3. Per-row validation via validate_interface for each row that has both subnet_ref and IP
+      3. Type-family consistency via find_type_family_mismatches so a row whose
+         'dg-interface-type' token contradicts its IP's family or its subnet's CIDR family is
+         flagged; rows without a token are skipped (legacy rows pre-date the selector)
+      4. Per-row validation via validate_interface for each row that has both subnet_ref and IP
          set; the row's index is injected into every per-row error's 'details.row_index' so the
          caller can map errors back to the originating row
 
@@ -502,7 +688,8 @@ def validate_interface_rows(
     Args:
         objects_manager (ObjectsManager): db interface for CmdbObjects
         types_manager (TypesManager): db interface for CmdbTypes
-        rows (list[tuple[int, int | None, str | None]]): (row_index, subnet_ref, ip) tuples
+        rows (list[tuple[int, int | None, str | None, str | None]]): (row_index, subnet_ref,
+            ip, interface_type) tuples
         exclude_object_id (int | None): public_id of the editing object so its own pre-edit
             row is not flagged as a collision against itself
 
@@ -514,8 +701,9 @@ def validate_interface_rows(
 
     errors: list[dict[str, Any]] = find_subnet_without_ip(rows)
     errors.extend(find_intra_submission_duplicates(rows))
+    errors.extend(find_type_family_mismatches(objects_manager, types_manager, rows))
 
-    for row_index, subnet_ref, ip in rows:
+    for row_index, subnet_ref, ip, _ in rows:
         if subnet_ref is None or ip is None:
             continue
 
@@ -529,7 +717,7 @@ def validate_interface_rows(
         )
 
         for err in row_errors:
-            err.setdefault('details', {})['row_index'] = row_index
+            err.setdefault(ValidationErrorKey.DETAILS, {})[IpamValidationDetailKey.ROW_INDEX] = row_index
 
         errors.extend(row_errors)
 

--- a/cmdb/framework/ipam/subnet_export.py
+++ b/cmdb/framework/ipam/subnet_export.py
@@ -14,13 +14,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-Excel (.xlsx) export of all assigned subnets of a supernet
+Excel (.xlsx) exports for the IPAM overviews
 
-Builds a single-sheet workbook listing every subnet referencing the supernet, one row each, with
-the columns CIDR, IP range (first - last), used IPs and free IPs. An IPv4 supernet's sheet also
-carries a trailing 'Usage (%)' column; an IPv6 supernet omits it, since a used/total ratio against
-a 2**n address space is meaningless. The subnet rows come from the same overview pipeline that
-powers the supernet view, so the exported figures match what the UI shows.
+Two single-sheet exports live here:
+- ``build_supernet_subnets_xlsx`` lists every subnet referencing a supernet, one row each, with the
+  columns CIDR, IP range (first - last), used IPs and free IPs. An IPv4 supernet's sheet also carries
+  a trailing 'Usage (%)' column; an IPv6 supernet omits it, since a used/total ratio against a 2**n
+  address space is meaningless.
+- ``build_subnet_ips_xlsx`` lists a subnet's IP-table rows, one row each, with the columns IP, type,
+  status, assigned-to summary and MAC. An IPv4 subnet exports all assignable addresses (free +
+  assigned); an IPv6 subnet exports only its assigned addresses.
+
+Both pull their rows from the same overview pipelines that power the UI, so the exported figures
+match what the user sees.
 """
 from logging import Logger, getLogger
 from typing import Any
@@ -30,8 +36,15 @@ from openpyxl import Workbook
 
 from cmdb.manager import ObjectsManager, TypesManager
 
-from cmdb.models.special_type_model.ipam_constants import IpamOverviewKey, IpamExport, IpAddressFamily
+from cmdb.models.special_type_model.ipam_constants import (
+    IpamOverviewKey,
+    IpamExport,
+    IpamSubnetIpsExport,
+    IpamRowStatus,
+    IpAddressFamily,
+)
 from cmdb.framework.ipam.supernet_overview import load_assigned_subnet_rows, resolve_supernet_family
+from cmdb.framework.ipam.subnet_overview import build_subnet_ip_export_rows
 # -------------------------------------------------------------------------------------------------------------------- #
 
 LOGGER: Logger = getLogger(__name__)
@@ -112,6 +125,77 @@ def build_supernet_subnets_xlsx(
 
     for row in rows:
         sheet.append(_subnet_export_row(row, include_usage=not is_ipv6))
+
+    buffer: BytesIO = BytesIO()
+    workbook.save(buffer)
+
+    return buffer.getvalue()
+
+
+def _subnet_ip_export_row(row: dict[str, Any]) -> list[Any]:
+    """
+    Maps one overview IP row to its export cell values, matching IpamSubnetIpsExport.HEADERS
+
+    The type and assigned-to columns carry the human-readable label / summary line (the same text
+    the UI shows); a free row leaves type, assigned-to and MAC blank. The status enum is written as
+    its plain value ('assigned' / 'free') - openpyxl would otherwise stringify the enum member to
+    'IpamRowStatus.ASSIGNED'.
+
+    Args:
+        row (dict[str, Any]): An IP-table row (assigned / free shape as produced by _compose_ip_row)
+
+    Returns:
+        list[Any]: [ip, type_label, status, assigned_to_summary, mac]
+    """
+    type_info: dict[str, Any] | None = row.get(IpamOverviewKey.TYPE_INFO)
+    assigned_to: dict[str, Any] | None = row.get(IpamOverviewKey.ASSIGNED_TO)
+    status: Any = row.get(IpamOverviewKey.STATUS)
+
+    return [
+        row.get(IpamOverviewKey.IP),
+        type_info.get(IpamOverviewKey.LABEL) if type_info else '',
+        status.value if isinstance(status, IpamRowStatus) else status,
+        assigned_to.get(IpamOverviewKey.SUMMARY_LINE) if assigned_to else '',
+        row.get(IpamOverviewKey.MAC_ADDRESS) or '',
+    ]
+
+
+def build_subnet_ips_xlsx(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    subnet_public_id: int,
+) -> bytes:
+    """
+    Builds an XLSX workbook listing a subnet's IP rows and returns its bytes
+
+    Validation of the subnet (exists / is a SUBNET / has a parsable range) and the oversized-export
+    guard (IpamSubnetIpsExport.MAX_EXPORT_ROWS) are delegated to ``build_subnet_ip_export_rows``,
+    which aborts before this function builds any workbook. IPv4 subnets export all assignable
+    addresses (free + assigned); IPv6 subnets export only the assigned ones. The column set is the
+    same for both families.
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        subnet_public_id (int): public_id of the SUBNET whose IPs are exported
+
+    Returns:
+        bytes: The serialized .xlsx workbook
+
+    Raises:
+        HTTPException: 404 / 400 propagated from ``build_subnet_ip_export_rows`` (bad id,
+            unparsable range, or an export exceeding the row limit)
+    """
+    rows: list[dict[str, Any]] = build_subnet_ip_export_rows(objects_manager, types_manager, subnet_public_id)
+
+    workbook: Workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = IpamSubnetIpsExport.SHEET_TITLE
+
+    sheet.append(IpamSubnetIpsExport.HEADERS)
+
+    for row in rows:
+        sheet.append(_subnet_ip_export_row(row))
 
     buffer: BytesIO = BytesIO()
     workbook.save(buffer)

--- a/cmdb/framework/ipam/subnet_options.py
+++ b/cmdb/framework/ipam/subnet_options.py
@@ -1,0 +1,178 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Builds the paginated subnet-options payload backing the dg-ipam-interface subnet picker
+
+The frontend's interface section lets the user pick an address family (ipv4 / ipv6) before
+choosing a subnet; the picker then loads only subnets of that family from here instead of the
+unfiltered generic objects route. The family of each subnet is resolved CIDR-first with the
+'dg-subnet-type' selector as fallback and IPv4 as legacy default (see ``subnet_family``), so
+legacy subnets without the selector and subnets whose selector contradicts their CIDR land in
+exactly the family every other IPAM view reports for them. Nothing is stored - this is a pure
+read model
+
+Rows reuse the lightweight sidebar-tree node shape (public_id, name, cidr, address family
+under 'type') and the shared display order: ascending network address with prefix length as
+tiebreaker (IPv4 before IPv6 in the unfiltered list), subnets with a missing or unparsable
+CIDR trailing their family group ordered by name. The envelope mirrors the assignable-objects
+picker: {page, page_size, total, search, type, rows}
+"""
+from typing import Any
+
+from cmdb.manager import ObjectsManager, TypesManager
+from cmdb.models.special_type_model.special_type_enum import SpecialType
+from cmdb.models.special_type_model.ipam_constants import IpamOverviewKey, IpamTreeKey
+from cmdb.framework.ipam.pagination import clamp_page
+from cmdb.framework.ipam.search import active_search
+from cmdb.framework.ipam.tree_overview import (
+    load_all_special_type_objects,
+    sort_tree_nodes,
+    subnet_tree_node,
+)
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                  PURE HELPERS                                                        #
+# -------------------------------------------------------------------------------------------------------------------- #
+def filter_nodes_by_family(nodes: list[dict[str, Any]], family: str) -> list[dict[str, Any]]:
+    """
+    Returns the nodes whose resolved address family equals the requested one
+
+    An empty / falsy ``family`` deactivates the filter and returns every node, so the route
+    can pass the raw query-param value straight through. The comparison reads the node's
+    'type' key, which carries the CIDR-first resolved family - the caller is expected to have
+    validated the token against IpAddressFamily already
+
+    Args:
+        nodes (list[dict[str, Any]]): Subnet nodes shaped by ``subnet_tree_node``
+        family (str): The requested IpAddressFamily token, or '' for no filtering
+
+    Returns:
+        list[dict[str, Any]]: Matching nodes in their original relative order (a new list)
+    """
+    if not family:
+        return list(nodes)
+
+    return [node for node in nodes if node.get(IpamTreeKey.TYPE) == family]
+
+
+def filter_nodes_by_search(nodes: list[dict[str, Any]], search: str) -> list[dict[str, Any]]:
+    """
+    Returns the nodes whose name or CIDR contains the query as a case-insensitive substring
+
+    The shared activation rule applies (see ``active_search``): an empty / whitespace query or
+    one shorter than IpamSearch.MIN_QUERY_LENGTH after stripping deactivates the filter and
+    returns every node. A node matches when either its 'name' or its 'cidr' is a string
+    containing the needle, so both '10.0' and a name fragment surface options; nodes where
+    both values are missing never match an active search
+
+    Args:
+        nodes (list[dict[str, Any]]): Subnet nodes shaped by ``subnet_tree_node``
+        search (str): Raw search query; whitespace handling and the minimum-length rule are
+            applied here, the MAX_QUERY_LENGTH truncation is the route's responsibility
+
+    Returns:
+        list[dict[str, Any]]: Matching nodes in their original relative order (a new list)
+    """
+    needle: str | None = active_search(search)
+
+    if needle is None:
+        return list(nodes)
+
+    lowered: str = needle.lower()
+    matches: list[dict[str, Any]] = []
+
+    for node in nodes:
+        name: Any = node.get(IpamTreeKey.NAME)
+        cidr: Any = node.get(IpamTreeKey.CIDR)
+
+        name_hit: bool = isinstance(name, str) and lowered in name.lower()
+        cidr_hit: bool = isinstance(cidr, str) and lowered in cidr.lower()
+
+        if name_hit or cidr_hit:
+            matches.append(node)
+
+    return matches
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   ORCHESTRATOR                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def build_subnet_options_page(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    *,
+    page: int,
+    page_size: int,
+    search: str,
+    family: str = '',
+) -> dict[str, Any]:
+    """
+    Builds the paginated subnet-options payload for the interface section's subnet picker
+
+    Steps:
+      1. Load every SUBNET CmdbObject via ``load_all_special_type_objects``. With no SUBNET
+         CmdbType defined the load yields no objects and the response collapses to an empty
+         page envelope instead of erroring
+      2. Shape each subnet into a lightweight node (public_id, name, cidr, family under
+         'type') and sort the full set into the shared display order via ``sort_tree_nodes``
+      3. Apply the family filter (skipped when ``family`` is empty), then the
+         case-insensitive name / CIDR substring filter (skipped when the normalized query is
+         shorter than IpamSearch.MIN_QUERY_LENGTH)
+      4. Compute the post-filter total, clamp the requested page / page_size into the valid
+         range via ``clamp_page``, and slice the page out of the filtered node list
+
+    All subnets are candidates regardless of supernet assignment - unassigned subnets must
+    stay selectable in interface rows
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        page (int): Requested 1-based page number; clamped server-side
+        page_size (int): Requested page size; clamped into [IpamPagination.MIN_PAGE_SIZE,
+            IpamPagination.MAX_PAGE_SIZE]
+        search (str): Raw search query; whitespace is stripped and queries shorter than
+            IpamSearch.MIN_QUERY_LENGTH are ignored. The MAX_QUERY_LENGTH truncation is the
+            route's responsibility
+        family (str): Optional IpAddressFamily token ('ipv4' / 'ipv6') restricting the rows
+            to one family; '' returns both families. Token validation is the route's
+            responsibility
+
+    Returns:
+        dict[str, Any]: {'page', 'page_size', 'total', 'search', 'type', 'rows': [...]} where
+            each row is {'public_id', 'name', 'cidr', 'type'} and 'total' is the count after
+            both filters, not the unfiltered count
+    """
+    subnet_objs: list[dict[str, Any]] = load_all_special_type_objects(
+        objects_manager, types_manager, SpecialType.SUBNET,
+    )
+
+    nodes: list[dict[str, Any]] = sort_tree_nodes([subnet_tree_node(s) for s in subnet_objs])
+    filtered: list[dict[str, Any]] = filter_nodes_by_search(filter_nodes_by_family(nodes, family), search)
+
+    total: int = len(filtered)
+    clamped_page, clamped_size = clamp_page(page, page_size, total)
+    start_offset: int = (clamped_page - 1) * clamped_size
+
+    return {
+        IpamOverviewKey.PAGE: clamped_page,
+        IpamOverviewKey.PAGE_SIZE: clamped_size,
+        IpamOverviewKey.TOTAL: total,
+        IpamOverviewKey.SEARCH: search,
+        IpamOverviewKey.TYPE: family,
+        IpamOverviewKey.ROWS: filtered[start_offset:start_offset + clamped_size],
+    }

--- a/cmdb/framework/ipam/subnet_overview.py
+++ b/cmdb/framework/ipam/subnet_overview.py
@@ -41,6 +41,7 @@ from cmdb.models.special_type_model.ipam_constants import (
     IpamBucketLabel,
     IpamSortColumn,
     IpamSortDirection,
+    IpamSubnetIpsExport,
 )
 from cmdb.framework.ipam.cidr import (
     Network,
@@ -1743,3 +1744,281 @@ def build_invalid_subnet_overview(
         ).get(public_id, []),
         IpamOverviewKey.INVALID_COUNT: invalid_count,
     }
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              SINGLE-SECTOR DRILL-DOWN                                                #
+# -------------------------------------------------------------------------------------------------------------------- #
+def _require_sector_grid(public_id: int, network: Network) -> int:
+    """
+    Returns the grid sector size for a subnet, aborting HTTP 400 when no full grid is exposed
+
+    Mirrors ``_build_ip_distribution``'s emit rule: the IP-Verteilung grid (and therefore any
+    clickable sector) only exists when the subnet fills the full MAX_RANGES x MAX_SECTORS grid
+    (/26 and shorter). Narrower subnets have no sectors, so the drill-down has nothing to resolve
+
+    Args:
+        public_id (int): public_id of the subnet (for the error message)
+        network (Network): The parsed subnet network
+
+    Returns:
+        int: The number of addresses each grid sector covers
+    """
+    ranges_count, sectors_per_range, sector_size = _compute_grid_dimensions(total_address_count(network))
+    max_grid_cells: int = IpamDistributionLimits.MAX_RANGES * IpamDistributionLimits.MAX_SECTORS_PER_RANGE
+
+    if ranges_count * sectors_per_range < max_grid_cells:
+        abort(400, f"Subnet with ID {public_id} is too small to expose an IP-distribution grid!")
+
+    return sector_size
+
+
+def _resolve_sector_bounds(network: Network, sector_start: Any, sector_size: int) -> tuple[int, int]:
+    """
+    Validates a sector-start address and returns the [lo, hi] integer bounds of that sector
+
+    The start must parse in the subnet's address family, sit inside the subnet, and align to a
+    sector boundary (offset divisible by ``sector_size``) so the window matches exactly one cell
+    of the IP-Verteilung grid. Any violation aborts HTTP 400
+
+    Args:
+        network (Network): The parsed subnet network
+        sector_start (Any): The candidate sector start address (canonical IP string)
+        sector_size (int): Number of addresses each grid cell covers
+
+    Returns:
+        tuple[int, int]: (sector_lo, sector_hi) inclusive integer bounds of the sector
+    """
+    start_addr: Address | None = parse_ip(sector_start) if isinstance(sector_start, str) else None
+
+    if start_addr is None or start_addr.version != network.version:
+        abort(400, f"'{sector_start}' is not a valid {network_family(network)} sector start address!")
+
+    offset: int = int(start_addr) - int(network.network_address)
+
+    if offset < 0 or offset >= total_address_count(network) or offset % sector_size != 0:
+        abort(400, f"'{sector_start}' is not an aligned sector boundary of this subnet!")
+
+    return int(network.network_address) + offset, int(network.network_address) + offset + sector_size - 1
+
+
+def _sector_assigned_only_page(
+    assigned: dict[str, dict[str, Any]],
+    sector_lo: int,
+    sector_hi: int,
+    page: int,
+    page_size: int,
+) -> tuple[list[str], int, int, int]:
+    """
+    Paginates the assigned IPs that fall inside a sector window (the IPv6 path - no free enumeration)
+
+    Args:
+        assigned (dict[str, dict[str, Any]]): {ip_str: row_info} as produced by _load_assigned_rows_map
+        sector_lo (int): Inclusive integer lower bound of the sector
+        sector_hi (int): Inclusive integer upper bound of the sector
+        page (int): Requested 1-based page number; clamped server-side
+        page_size (int): Requested page size; clamped server-side
+
+    Returns:
+        tuple[list[str], int, int, int]: (page_ips, total_count, safe_page, safe_size)
+    """
+    candidates: list[str] = [
+        ip for ip in _sorted_assigned_ips(assigned, valid=True)
+        if sector_lo <= int(parse_ip(ip)) <= sector_hi
+    ]
+    safe_page, safe_size = clamp_page(page, page_size, len(candidates))
+    start: int = (safe_page - 1) * safe_size
+
+    return candidates[start:start + safe_size], len(candidates), safe_page, safe_size
+
+
+def _sector_assignable_page(
+    network: Network,
+    sector_lo: int,
+    sector_hi: int,
+    page: int,
+    page_size: int,
+) -> tuple[list[str], int, int, int]:
+    """
+    Paginates the assignable addresses (free + assigned) inside a sector window (the IPv4 path)
+
+    The sector window is intersected with the subnet's contiguous assignable range so the
+    network / broadcast addresses are excluded at the first / last sector exactly as the full IP
+    table excludes them. The page is sliced by integer offset (O(page_size)), so even a sector of
+    a large subnet paginates without materializing the whole window
+
+    Args:
+        network (Network): The parsed subnet network (IPv4)
+        sector_lo (int): Inclusive integer lower bound of the sector
+        sector_hi (int): Inclusive integer upper bound of the sector
+        page (int): Requested 1-based page number; clamped server-side
+        page_size (int): Requested page size; clamped server-side
+
+    Returns:
+        tuple[list[str], int, int, int]: (page_ips, total_count, safe_page, safe_size)
+    """
+    assignable_lo: int = first_assignable_int(network)
+    assignable_hi: int = assignable_lo + assignable_address_count(network) - 1
+
+    lo: int = max(sector_lo, assignable_lo)
+    hi: int = min(sector_hi, assignable_hi)
+    total_count: int = max(0, hi - lo + 1)
+
+    safe_page, safe_size = clamp_page(page, page_size, total_count)
+    start: int = (safe_page - 1) * safe_size
+    end: int = min(start + safe_size, total_count)
+    page_ips: list[str] = [_format_ip(lo + offset, False) for offset in range(start, end)]
+
+    return page_ips, total_count, safe_page, safe_size
+
+
+def build_subnet_sector_ips(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    public_id: int,
+    sector_start: Any,
+    page: int = 1,
+    page_size: int = IpamPagination.DEFAULT_PAGE_SIZE,
+) -> dict[str, Any]:
+    """
+    Builds the paginated IP list for a single IP-Verteilung sector of a subnet
+
+    Backs the 'click a heatmap sector' drill-down: instead of the whole subnet, only the IPs of
+    the clicked sector are returned. The sector window is derived from the same grid dimensions
+    the overview's ip_distribution used, so it matches the clicked cell exactly. For IPv4 the page
+    lists the sector's assignable addresses (free + assigned, network / broadcast excluded); for
+    IPv6 it lists only the assigned addresses inside the sector (never enumerating the space). Rows
+    reuse the IP-table row shape (assigned / free) so the frontend can render the same row template
+
+    Aborts HTTP 404 when the subnet does not exist, HTTP 400 when the public_id is not a SUBNET /
+    no SUBNET CmdbType is defined, when the subnet has no grid (CIDR missing / unparsable, or the
+    subnet is too small to expose the full grid), or when ``sector_start`` is not an aligned sector
+    boundary of the subnet
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        public_id (int): public_id of the SUBNET CmdbObject
+        sector_start (Any): The clicked sector's start address (its ip_start from ip_distribution)
+        page (int): 1-based page number for the sector's IP list (clamped server-side)
+        page_size (int): Page size (clamped to [IpamPagination.MIN_PAGE_SIZE, MAX_PAGE_SIZE])
+
+    Returns:
+        dict[str, Any]: {'sector': {ip_start, ip_end}, 'ips': {page, page_size, total, rows}}
+    """
+    subnet_obj: dict[str, Any] = _load_subnet_object(objects_manager, types_manager, public_id)
+    network: Network | None = _parse_subnet_network(subnet_obj)
+
+    if network is None:
+        abort(400, f"Subnet with ID {public_id} has no IP-distribution grid (network range missing or unparsable)!")
+
+    sector_size: int = _require_sector_grid(public_id, network)
+    sector_lo, sector_hi = _resolve_sector_bounds(network, sector_start, sector_size)
+
+    assigned: dict[str, dict[str, Any]] = _load_assigned_rows_map(objects_manager, public_id, network)
+    type_meta: dict[int, dict[str, Any]] = _resolve_type_meta(types_manager, [
+        info[_AssignedField.TYPE_ID]
+        for info in assigned.values()
+        if isinstance(info.get(_AssignedField.TYPE_ID), int)
+    ])
+
+    is_ipv6: bool = network_family(network) == IpAddressFamily.IPV6
+    page_ips, total_count, safe_page, safe_size = (
+        _sector_assigned_only_page(assigned, sector_lo, sector_hi, page, page_size)
+        if is_ipv6
+        else _sector_assignable_page(network, sector_lo, sector_hi, page, page_size)
+    )
+
+    return {
+        IpamOverviewKey.SECTOR: {
+            IpamOverviewKey.IP_START: _format_ip(sector_lo, is_ipv6),
+            IpamOverviewKey.IP_END: _format_ip(sector_hi, is_ipv6),
+        },
+        IpamOverviewKey.IPS: {
+            IpamOverviewKey.PAGE: safe_page,
+            IpamOverviewKey.PAGE_SIZE: safe_size,
+            IpamOverviewKey.TOTAL: total_count,
+            IpamOverviewKey.ROWS: [
+                _compose_ip_row(ip, assigned, type_meta, objects_manager) for ip in page_ips
+            ],
+        },
+    }
+
+
+def _abort_if_export_too_big(public_id: int, row_count: int) -> None:
+    """
+    Aborts HTTP 400 when ``row_count`` exceeds IpamSubnetIpsExport.MAX_EXPORT_ROWS
+
+    Guards the IP export so an oversized subnet is rejected before any workbook is built. The
+    counted volume is the family-specific export size the caller computed cheaply (the IPv4
+    assignable count or the IPv6 assigned count), never an enumerated address space
+
+    Args:
+        public_id (int): public_id of the subnet being exported (for the error message)
+        row_count (int): Number of IP rows the export would emit
+
+    Raises:
+        HTTPException: 400 when ``row_count`` is over the export limit
+    """
+    if row_count > IpamSubnetIpsExport.MAX_EXPORT_ROWS:
+        abort(
+            400,
+            f"Subnet with ID {public_id} is too big to export: {row_count} entries exceed the "
+            f"{IpamSubnetIpsExport.MAX_EXPORT_ROWS}-row export limit!",
+        )
+
+
+def build_subnet_ip_export_rows(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    public_id: int,
+) -> list[dict[str, Any]]:
+    """
+    Builds every IP-table row of a subnet for the Excel export, in ascending IP order
+
+    Mirrors the default (unfiltered) IP table of ``build_subnet_overview``: an IPv4 subnet
+    exports all in-CIDR assignable addresses (free + assigned), an IPv6 subnet exports only its
+    in-CIDR assigned addresses. The out-of-CIDR (invalid) rows surfaced by the separate
+    ``/invalid`` view are not part of the export.
+
+    The export size is checked against IpamSubnetIpsExport.MAX_EXPORT_ROWS BEFORE any address
+    space is enumerated - for IPv4 against the cheap ``assignable_address_count`` and for IPv6
+    against the already-loaded assigned-row count - so an oversized subnet aborts 400 without
+    materializing a multi-thousand-entry list
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        public_id (int): public_id of the subnet whose IPs are exported
+
+    Returns:
+        list[dict[str, Any]]: IP-table rows (assigned / free shapes as produced by
+            ``_compose_ip_row``) in ascending IP order
+
+    Raises:
+        HTTPException: 404 / 400 from ``_load_subnet_object`` (missing or non-subnet object),
+            400 when the subnet's network range is missing / unparsable, and 400 when the
+            export would exceed IpamSubnetIpsExport.MAX_EXPORT_ROWS
+    """
+    subnet_obj: dict[str, Any] = _load_subnet_object(objects_manager, types_manager, public_id)
+    network: Network | None = _parse_subnet_network(subnet_obj)
+
+    if network is None:
+        abort(400, f"Subnet with ID {public_id} has no exportable IPs: its network range is missing or invalid!")
+
+    assigned: dict[str, dict[str, Any]] = _load_assigned_rows_map(objects_manager, public_id, network)
+
+    if network_family(network) == IpAddressFamily.IPV6:
+        candidate_ips: list[str] = _sorted_assigned_ips(assigned, valid=True)
+        _abort_if_export_too_big(public_id, len(candidate_ips))
+    else:
+        _abort_if_export_too_big(public_id, assignable_address_count(network))
+        candidate_ips = list_all_assignable_ips(network)
+
+    type_meta: dict[int, dict[str, Any]] = _resolve_type_meta(types_manager, [
+        info[_AssignedField.TYPE_ID]
+        for info in assigned.values()
+        if isinstance(info.get(_AssignedField.TYPE_ID), int)
+    ])
+
+    return [_compose_ip_row(ip, assigned, type_meta, objects_manager) for ip in candidate_ips]

--- a/cmdb/framework/ipam/subnet_unassign.py
+++ b/cmdb/framework/ipam/subnet_unassign.py
@@ -51,6 +51,7 @@ from cmdb.models.special_type_model.ipam_constants import (
     InterfaceField,
     IpamSection,
     IpamUnassignKey,
+    IpamUnassignMode,
 )
 from cmdb.models.user_model import CmdbUser
 from cmdb.security.acl.permission import AccessControlPermission
@@ -248,6 +249,100 @@ def clear_subnet_ref_in_owner(
     return new_doc, total_cleared
 
 
+def delete_subnet_rows(
+    rows: list[dict[str, Any]],
+    subnet_id: int,
+    target_ips: set[str],
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """
+    Returns the row list with each target row removed entirely, plus the set of removed IPs
+
+    A row is a target when it references this subnet AND its IP is in ``target_ips`` (the same
+    predicate ``clear_subnet_ref_in_rows`` uses). Target rows are dropped from the returned list
+    rather than rewritten, so the whole dg-ipam-interface entry (IP, MAC and all) disappears.
+    Non-target rows pass through unchanged. The removed-IP set is built from rows actually
+    dropped, so an empty ``target_ips`` or rows referencing a different subnet do not inflate it
+
+    Args:
+        rows (list[dict[str, Any]]): The 'values' list of a dg-ipam-interface MDS section
+        subnet_id (int): public_id of the subnet whose rows should be removed
+        target_ips (set[str]): Canonical IP strings flagged for removal
+
+    Returns:
+        tuple[list[dict[str, Any]], set[str]]: (new rows list without the target rows, set of
+            canonical IPs whose row was removed)
+    """
+    new_rows: list[dict[str, Any]] = []
+    removed: set[str] = set()
+
+    for row in rows:
+        row_subnet: Any = None
+        row_ip: Any = None
+
+        for entry in row.get(CmdbObjectMdsRowKey.DATA, []) or []:
+            name: Any = entry.get(CmdbObjectFieldKey.NAME)
+
+            if name == InterfaceField.SUBNET:
+                row_subnet = entry.get(CmdbObjectFieldKey.VALUE)
+            elif name == InterfaceField.IP:
+                row_ip = entry.get(CmdbObjectFieldKey.VALUE)
+
+        if row_subnet == subnet_id and isinstance(row_ip, str) and row_ip in target_ips:
+            removed.add(row_ip)
+            continue
+
+        new_rows.append(row)
+
+    return new_rows, removed
+
+
+def delete_subnet_rows_in_owner(
+    owner_doc: dict[str, Any],
+    subnet_id: int,
+    target_ips: set[str],
+) -> tuple[dict[str, Any], set[str]]:
+    """
+    Returns a copy of the owner with every matching dg-ipam-interface row removed
+
+    Parallel to ``clear_subnet_ref_in_owner`` but uses ``delete_subnet_rows`` so the matched rows
+    are dropped from each dg-ipam-interface section's 'values' rather than having their subnet ref
+    blanked. Other sections and non-target rows pass through unchanged. Operates on shallow copies
+    (new doc, new section dicts); surviving rows are forwarded by reference
+
+    Args:
+        owner_doc (dict[str, Any]): The CmdbObject document to delete rows from
+        subnet_id (int): public_id of the subnet whose rows should be removed
+        target_ips (set[str]): Canonical IP strings flagged for removal
+
+    Returns:
+        tuple[dict[str, Any], set[str]]: (new owner doc, set of canonical IPs whose row was
+            removed on this owner)
+    """
+    new_doc: dict[str, Any] = dict(owner_doc)
+    new_sections: list[dict[str, Any]] = []
+    total_removed: set[str] = set()
+
+    for section in owner_doc.get(CmdbObjectKey.MULTI_DATA_SECTIONS, []) or []:
+        if section.get(CmdbObjectMdsKey.SECTION_ID) != IpamSection.INTERFACE:
+            new_sections.append(section)
+            continue
+
+        new_values, removed_ips = delete_subnet_rows(
+            section.get(CmdbObjectMdsKey.VALUES, []) or [],
+            subnet_id,
+            target_ips,
+        )
+        total_removed |= removed_ips
+
+        new_section: dict[str, Any] = dict(section)
+        new_section[CmdbObjectMdsKey.VALUES] = new_values
+        new_sections.append(new_section)
+
+    new_doc[CmdbObjectKey.MULTI_DATA_SECTIONS] = new_sections
+
+    return new_doc, total_removed
+
+
 def collect_present_ips(
     owner_docs: list[dict[str, Any]],
     subnet_id: int,
@@ -408,42 +503,51 @@ def load_interface_owners(
 # -------------------------------------------------------------------------------------------------------------------- #
 #                                                      WRITES                                                          #
 # -------------------------------------------------------------------------------------------------------------------- #
-def clear_subnet_ref_in_owners(
+# Per-owner mutators keyed by unassign mode: each takes (owner_doc, subnet_id, target_ips) and
+# returns (new_owner_doc, set_of_affected_ips). REFERENCE blanks the subnet ref; ROW drops the row
+_OWNER_MUTATORS = {
+    IpamUnassignMode.REFERENCE: clear_subnet_ref_in_owner,
+    IpamUnassignMode.ROW: delete_subnet_rows_in_owner,
+}
+
+
+def apply_unassign_to_owners(
     objects_manager: ObjectsManager,
     owner_docs: list[dict[str, Any]],
     subnet_id: int,
     target_ips: set[str],
     request_user: CmdbUser,
+    mode: str,
 ) -> int:
     """
-    Clears the subnet ref on each owner's matching rows and returns the total cleared-row count
+    Applies the chosen unassign ``mode`` to each owner's matching rows and returns the affected count
 
-    Iterates the candidate owners, runs ``clear_subnet_ref_in_owner`` to build the post-clear
-    doc, and only calls ``objects_manager.update_object`` for owners that actually had at
-    least one row's subnet ref cleared (so an owner that referenced this subnet only at non-
-    target IPs is skipped and incurs no write). Each ``update_object`` call goes through the
-    standard ACL / version / hook path so a user without UPDATE permission on the owner's
-    CmdbType fails fast
+    Iterates the candidate owners, builds the post-mutation doc with the mode's per-owner mutator
+    (REFERENCE -> ``clear_subnet_ref_in_owner``, ROW -> ``delete_subnet_rows_in_owner``), and only
+    calls ``objects_manager.update_object`` for owners that actually changed (so an owner that
+    referenced this subnet only at non-target IPs is skipped and incurs no write). Each
+    ``update_object`` goes through the standard ACL / version / hook path, so a user without UPDATE
+    permission on the owner's CmdbType fails fast. Note the per-owner writes are sequential and not
+    wrapped in a cross-owner transaction
 
     Args:
         objects_manager (ObjectsManager): db interface for CmdbObjects
-        owner_docs (list[dict[str, Any]]): Candidate owners (typically from
-            ``load_interface_owners``)
-        subnet_id (int): public_id of the subnet whose interface rows should have their ref
-            cleared
-        target_ips (set[str]): Canonical IPv4 strings flagged for clearing
+        owner_docs (list[dict[str, Any]]): Candidate owners (typically from ``load_interface_owners``)
+        subnet_id (int): public_id of the subnet whose interface rows are unassigned
+        target_ips (set[str]): Canonical IP strings flagged for unassigning
         request_user (CmdbUser): User making the request; forwarded to update_object for ACL
+        mode (str): An IpamUnassignMode value selecting the per-owner mutation
 
     Returns:
-        int: Total number of dg-ipam-interface rows whose subnet ref was cleared across all
-            touched owners
+        int: Total number of dg-ipam-interface rows affected across all touched owners
     """
-    total_cleared: int = 0
+    mutate = _OWNER_MUTATORS[mode]
+    total_affected: int = 0
 
     for owner in owner_docs:
-        new_doc, cleared = clear_subnet_ref_in_owner(owner, subnet_id, target_ips)
+        new_doc, affected = mutate(owner, subnet_id, target_ips)
 
-        if not cleared:
+        if not affected:
             continue
 
         objects_manager.update_object(
@@ -452,37 +556,94 @@ def clear_subnet_ref_in_owners(
             request_user,
             AccessControlPermission.UPDATE,
         )
-        total_cleared += len(cleared)
+        total_affected += len(affected)
 
-    return total_cleared
+    return total_affected
+
+
+def clear_subnet_ref_in_owners(
+    objects_manager: ObjectsManager,
+    owner_docs: list[dict[str, Any]],
+    subnet_id: int,
+    target_ips: set[str],
+    request_user: CmdbUser,
+) -> int:
+    """
+    Clears the subnet ref on each owner's matching rows (the REFERENCE mode of unassign)
+
+    Thin wrapper over ``apply_unassign_to_owners`` bound to IpamUnassignMode.REFERENCE; see that
+    helper for the per-owner write semantics
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        owner_docs (list[dict[str, Any]]): Candidate owners (typically from ``load_interface_owners``)
+        subnet_id (int): public_id of the subnet whose interface rows should have their ref cleared
+        target_ips (set[str]): Canonical IP strings flagged for clearing
+        request_user (CmdbUser): User making the request; forwarded to update_object for ACL
+
+    Returns:
+        int: Total number of dg-ipam-interface rows whose subnet ref was cleared
+    """
+    return apply_unassign_to_owners(
+        objects_manager, owner_docs, subnet_id, target_ips, request_user, IpamUnassignMode.REFERENCE,
+    )
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
 #                                                   ORCHESTRATOR                                                       #
 # -------------------------------------------------------------------------------------------------------------------- #
+def _resolve_unassign_mode(raw_mode: Any) -> str:
+    """
+    Normalizes the request 'mode' value to an IpamUnassignMode, defaulting to REFERENCE
+
+    A missing / empty mode falls back to REFERENCE (clear the subnet ref - the original behaviour),
+    a recognised value is returned as-is, and any other value aborts HTTP 400
+
+    Args:
+        raw_mode (Any): The raw value read off the JSON body for the 'mode' key
+
+    Returns:
+        str: A valid IpamUnassignMode value
+    """
+    if raw_mode is None or raw_mode == '':
+        return IpamUnassignMode.REFERENCE
+
+    if not IpamUnassignMode.is_valid(raw_mode):
+        abort(
+            400,
+            f"'{raw_mode}' is not a valid unassign mode "
+            f"(expected '{IpamUnassignMode.REFERENCE}' or '{IpamUnassignMode.ROW}')!",
+        )
+
+    return IpamUnassignMode(raw_mode)
+
+
 def unassign_ips_from_subnet(
     objects_manager: ObjectsManager,
     types_manager: TypesManager,
     subnet_public_id: int,
     raw_ips: Any,
     request_user: CmdbUser,
+    raw_mode: Any = None,
 ) -> dict[str, Any]:
     """
-    Validates the payload and clears the subnet reference on the matching dg-ipam-interface rows
+    Validates the payload and unassigns the matching dg-ipam-interface rows in the chosen mode
 
     Pipeline:
       1. Confirm ``subnet_public_id`` resolves to a SUBNET CmdbObject and parse its CIDR
          (aborts 400/404 on missing / wrong type / broken CIDR)
-      2. Coerce ``raw_ips`` to a deduplicated list of canonical IPv4 strings, each within the
+      2. Resolve ``raw_mode`` to an IpamUnassignMode (default REFERENCE; aborts 400 on an
+         unknown value)
+      3. Coerce ``raw_ips`` to a deduplicated list of canonical IP strings, each within the
          subnet (aborts 400 on bad shape / non-string / non-canonical / out-of-network)
-      3. Load every CmdbObject with a dg-ipam-interface row referencing this subnet
-      4. Collect the set of IPs currently assigned within the subnet; if any requested IP is
+      4. Load every CmdbObject with a dg-ipam-interface row referencing this subnet
+      5. Collect the set of IPs currently assigned within the subnet; if any requested IP is
          absent, abort 400 with the offending IPs - the call is validate-all-or-nothing, so
          no write happens
-      5. Otherwise call ``clear_subnet_ref_in_owners`` to flip the ``dg-interface-subnet``
-         value to None on each matching row, each via ``objects_manager.update_object`` so
-         ACL / versioning / hooks all run. The rows themselves and their IP / MAC values are
-         preserved
+      6. Otherwise apply the mode via ``apply_unassign_to_owners``: REFERENCE flips each matching
+         row's ``dg-interface-subnet`` value to None (the row, IP and MAC are kept); ROW deletes
+         the whole matching row. Each owner is written via ``objects_manager.update_object`` so
+         ACL / versioning / hooks all run. The mode applies to every IP, not per row
 
     Args:
         objects_manager (ObjectsManager): db interface for CmdbObjects
@@ -490,14 +651,16 @@ def unassign_ips_from_subnet(
         subnet_public_id (int): public_id of the SUBNET to unassign rows from
         raw_ips (Any): The raw value read off the JSON body for the 'ips' key
         request_user (CmdbUser): User making the request; forwarded to update_object for ACL
+        raw_mode (Any): The raw value read off the JSON body for the 'mode' key (default REFERENCE)
 
     Returns:
-        dict[str, Any]: {'ips': [str, ...], 'unassigned_count': int} where 'ips' echoes the
-            deduplicated request order and 'unassigned_count' is the number of
-            dg-ipam-interface rows whose subnet reference was cleared
+        dict[str, Any]: {'ips': [str, ...], 'mode': str, 'unassigned_count': int} where 'ips'
+            echoes the deduplicated request order, 'mode' echoes the resolved mode and
+            'unassigned_count' is the number of dg-ipam-interface rows affected
     """
     subnet_obj: dict[str, Any] = assert_subnet_exists(objects_manager, types_manager, subnet_public_id)
     network: Network = parse_subnet_network(subnet_obj)
+    mode: str = _resolve_unassign_mode(raw_mode)
     ips: list[str] = normalize_ip_list(raw_ips, network)
 
     owner_docs: list[dict[str, Any]] = load_interface_owners(objects_manager, subnet_public_id)
@@ -511,11 +674,12 @@ def unassign_ips_from_subnet(
             f" {subnet_public_id}!",
         )
 
-    unassigned_count: int = clear_subnet_ref_in_owners(
-        objects_manager, owner_docs, subnet_public_id, set(ips), request_user,
+    unassigned_count: int = apply_unassign_to_owners(
+        objects_manager, owner_docs, subnet_public_id, set(ips), request_user, mode,
     )
 
     return {
         IpamUnassignKey.IPS: ips,
+        IpamUnassignKey.MODE: mode,
         IpamUnassignKey.UNASSIGNED_COUNT: unassigned_count,
     }

--- a/cmdb/framework/ipam/supernet_overview.py
+++ b/cmdb/framework/ipam/supernet_overview.py
@@ -132,7 +132,7 @@ def _resolve_family(obj: dict[str, Any], type_field: str, range_field: str) -> s
     return IpAddressFamily.IPV6 if raw_type == IpAddressFamily.IPV6 else IpAddressFamily.IPV4
 
 
-def _subnet_family(subnet_obj: dict[str, Any]) -> str:
+def subnet_family(subnet_obj: dict[str, Any]) -> str:
     """
     Returns the address family of a SUBNET CmdbObject as an IpAddressFamily value ('ipv4' / 'ipv6')
 
@@ -148,7 +148,7 @@ def _subnet_family(subnet_obj: dict[str, Any]) -> str:
     return _resolve_family(subnet_obj, SubnetField.TYPE, SubnetField.NETWORK_RANGE)
 
 
-def _supernet_family(supernet_obj: dict[str, Any]) -> str:
+def supernet_family(supernet_obj: dict[str, Any]) -> str:
     """
     Returns the address family of a SUPERNET CmdbObject as an IpAddressFamily value ('ipv4' / 'ipv6')
 
@@ -182,14 +182,14 @@ def compute_subnet_row(subnet_obj: dict[str, Any], used_count: int) -> dict[str,
     Returns:
         dict[str, Any]: One row with public_id, subnet_type, cidr, ip_range, used_ips, free_ips,
                         usage_percent. 'subnet_type' is the row's address family ('ipv4' / 'ipv6';
-                        see _subnet_family). 'usage_percent' is None for IPv6 rows (an address
+                        see subnet_family). 'usage_percent' is None for IPv6 rows (an address
                         ratio against a 2**n space is meaningless) and a percentage for IPv4.
                         'ip_range' is the subnet's full network range ({first, last}), or None
                         when the CIDR is missing/unparsable
     """
     raw_cidr: Any = extract_field_value(subnet_obj, SubnetField.NETWORK_RANGE)
     network: Network | None = parse_cidr(raw_cidr) if isinstance(raw_cidr, str) else None
-    subnet_type: str = _subnet_family(subnet_obj)
+    subnet_type: str = subnet_family(subnet_obj)
     is_ipv6: bool = subnet_type == IpAddressFamily.IPV6
 
     if network is None:
@@ -624,7 +624,7 @@ def _paginate_rows(
 # -------------------------------------------------------------------------------------------------------------------- #
 #                                                   DATA LOADING                                                       #
 # -------------------------------------------------------------------------------------------------------------------- #
-def _load_supernet_object(
+def load_supernet_object(
     objects_manager: ObjectsManager,
     types_manager: TypesManager,
     public_id: int,
@@ -685,7 +685,7 @@ def _parse_supernet_cidr(supernet_obj: dict[str, Any]) -> Network | None:
     return parse_cidr(raw_cidr)
 
 
-def _load_subnets_for_supernet(
+def load_subnets_for_supernet(
     objects_manager: ObjectsManager,
     types_manager: TypesManager,
     supernet_public_id: int,
@@ -843,7 +843,7 @@ def _build_linked_subnet_rows(
         list[dict[str, Any]]: Subnet rows sorted by ascending CIDR with ``parent_id`` set and
             ``vlans`` populated; rows with unparsable CIDRs trail the sorted block
     """
-    subnet_objs: list[dict[str, Any]] = _load_subnets_for_supernet(
+    subnet_objs: list[dict[str, Any]] = load_subnets_for_supernet(
         objects_manager, types_manager, supernet_public_id,
     )
     subnet_ids: list[int] = [s[CmdbObjectKey.PUBLIC_ID] for s in subnet_objs if CmdbObjectKey.PUBLIC_ID in s]
@@ -885,7 +885,7 @@ def load_assigned_subnet_rows(
     Returns:
         list[dict[str, Any]]: All assigned subnet rows (see compute_subnet_row / _build_linked_subnet_rows)
     """
-    _load_supernet_object(objects_manager, types_manager, supernet_public_id)
+    load_supernet_object(objects_manager, types_manager, supernet_public_id)
 
     return _build_linked_subnet_rows(objects_manager, types_manager, supernet_public_id)
 
@@ -899,7 +899,7 @@ def resolve_supernet_family(
     Returns the address family ('ipv4' / 'ipv6') of a SUPERNET, loading and validating it first
 
     Loads the supernet exactly like the overview routes (aborting 400/404 on a bad id) and
-    resolves its family via ``_supernet_family`` (CIDR-first, selector fallback). Intended for
+    resolves its family via ``supernet_family`` (CIDR-first, selector fallback). Intended for
     callers that need the family without the subnet rows - e.g. the subnets export, which uses
     it to decide whether the IPv4-only 'Usage (%)' column belongs in the sheet
 
@@ -911,9 +911,9 @@ def resolve_supernet_family(
     Returns:
         str: IpAddressFamily.IPV6 or IpAddressFamily.IPV4
     """
-    supernet_obj: dict[str, Any] = _load_supernet_object(objects_manager, types_manager, supernet_public_id)
+    supernet_obj: dict[str, Any] = load_supernet_object(objects_manager, types_manager, supernet_public_id)
 
-    return _supernet_family(supernet_obj)
+    return supernet_family(supernet_obj)
 
 
 def _summarize_supernet(
@@ -972,9 +972,9 @@ def _prepare_supernet_view(
             (supernet CmdbObject document, annotated rows in CIDR order, KPI summary dict,
             total number of invalid rows across the full row set)
     """
-    supernet_obj: dict[str, Any] = _load_supernet_object(objects_manager, types_manager, public_id)
+    supernet_obj: dict[str, Any] = load_supernet_object(objects_manager, types_manager, public_id)
     supernet_network: Network | None = _parse_supernet_cidr(supernet_obj)
-    family: str = _supernet_family(supernet_obj)
+    family: str = supernet_family(supernet_obj)
 
     ordered_subnets: list[dict[str, Any]] = _build_linked_subnet_rows(
         objects_manager, types_manager, public_id,
@@ -1092,7 +1092,7 @@ def build_supernet_subnet_children(
     Returns:
         dict[str, Any]: {'parent': {'public_id': subnet_public_id}, 'rows': [child_row, ...]}
     """
-    supernet_obj: dict[str, Any] = _load_supernet_object(
+    supernet_obj: dict[str, Any] = load_supernet_object(
         objects_manager, types_manager, supernet_public_id,
     )
 

--- a/cmdb/framework/ipam/tree_overview.py
+++ b/cmdb/framework/ipam/tree_overview.py
@@ -1,0 +1,449 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Builds the data payloads for the IPAM sidebar tree
+
+The frontend renders a locations-style sidebar tree of all SUPERNETs and their SUBNETs. The
+initial payload (``build_ipam_tree``) is one call: a flat list of every SUPERNET (each entry
+carrying 'has_children' so the FE can render an expand caret without a probe request) plus a
+flat list of every unassigned SUBNET - one whose 'dg-supernet-ref' is empty. Expanding a
+supernet fetches its full CIDR-nested subnet subtree in one call
+(``build_supernet_subnet_tree``); ``build_unassigned_subnets`` re-fetches the unassigned block
+alone for targeted refreshes
+
+Tree nodes are intentionally lightweight - public_id, name, cidr and the address family under
+'type' - and skip the interface-IP counting, VLAN resolution and validity annotation the
+overview rows carry. Nesting reuses the overview's CIDR-containment semantics (a node's parent
+is the most-specific sibling that strictly contains it); the unassigned block stays flat
+because standalone subnets are an unstructured bucket (no overlap rules apply to them). Every
+list - the supernet block, the unassigned block and each 'children' array - is sorted IPv4
+before IPv6, then by ascending network address with prefix length as tiebreaker; nodes with a
+missing or unparsable CIDR trail their family group ordered by name
+"""
+from typing import Any
+
+from cmdb.manager import ObjectsManager, TypesManager
+from cmdb.models.object_model import CmdbObjectKey, extract_field_value
+from cmdb.models.special_type_model.special_type_enum import SpecialType
+from cmdb.models.special_type_model.ipam_constants import (
+    SupernetField,
+    SubnetField,
+    IpAddressFamily,
+    IpamTreeKey,
+)
+from cmdb.framework.ipam.cidr import Network, parse_cidr, is_strict_subnet
+from cmdb.framework.ipam.references import resolve_special_type_id
+from cmdb.framework.ipam.supernet_overview import (
+    load_supernet_object,
+    load_subnets_for_supernet,
+    subnet_family,
+    supernet_family,
+)
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                  PURE HELPERS                                                        #
+# -------------------------------------------------------------------------------------------------------------------- #
+def _coerce_ref_id(value: Any) -> int | None:
+    """
+    Coerces a stored reference-field value into an int public_id when possible, else None
+
+    Mirrors the coercion the IPAM enforcement layer applies to 'dg-supernet-ref': None, the
+    empty string and 0 are 'no reference', and any value that does not convert cleanly to an
+    int (e.g. a garbage string) is treated the same way
+
+    Args:
+        value (Any): The raw field value
+
+    Returns:
+        int | None: The integer public_id, or None when 'value' carries no usable reference
+    """
+    if value is None or value == '' or value == 0:
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parent_supernet_id(subnet_obj: dict[str, Any]) -> int | None:
+    """
+    Returns the public_id of the supernet a SUBNET references, or None when unassigned
+
+    Reads the subnet's 'dg-supernet-ref' field and coerces it via ``_coerce_ref_id``, so a
+    subnet whose reference field is missing, cleared or unusable counts as unassigned
+
+    Args:
+        subnet_obj (dict[str, Any]): The SUBNET CmdbObject document
+
+    Returns:
+        int | None: The referenced supernet's public_id, or None when the subnet is unassigned
+    """
+    return _coerce_ref_id(extract_field_value(subnet_obj, SubnetField.PARENT_SUPERNET))
+
+
+def _collect_referenced_supernet_ids(subnet_objs: list[dict[str, Any]]) -> set[int]:
+    """
+    Returns the set of supernet public_ids referenced by at least one of the given SUBNETs
+
+    Drives the 'has_children' flag on the supernet entries of the initial tree payload: a
+    supernet whose public_id is absent from the set has no assigned subnet. Dangling
+    references (a ref pointing at a deleted supernet) are included - they simply never match
+    a listed supernet
+
+    Args:
+        subnet_objs (list[dict[str, Any]]): SUBNET CmdbObject documents
+
+    Returns:
+        set[int]: public_ids of every supernet referenced by at least one subnet
+    """
+    referenced: set[int] = set()
+
+    for subnet_obj in subnet_objs:
+        supernet_id: int | None = _parent_supernet_id(subnet_obj)
+
+        if supernet_id is not None:
+            referenced.add(supernet_id)
+
+    return referenced
+
+
+def _shape_tree_node(
+    obj: dict[str, Any],
+    name_field: str,
+    range_field: str,
+    family: str,
+) -> dict[str, Any]:
+    """
+    Shapes one IPAM CmdbObject into a lightweight sidebar-tree node
+
+    The CIDR is normalised to its canonical string form when it parses; an unparsable string
+    is passed through verbatim so the FE can still display it, and a missing / non-string
+    value becomes None. The name is passed through only when it is a string
+
+    Args:
+        obj (dict[str, Any]): The SUBNET or SUPERNET CmdbObject document
+        name_field (str): The name field to read (SubnetField.NAME / SupernetField.NAME)
+        range_field (str): The network-range field to read (SubnetField.NETWORK_RANGE /
+            SupernetField.NETWORK_RANGE)
+        family (str): The object's resolved IpAddressFamily ('ipv4' / 'ipv6')
+
+    Returns:
+        dict[str, Any]: One node with public_id, name, cidr and the address family under 'type'
+    """
+    raw_cidr: Any = extract_field_value(obj, range_field)
+    network: Network | None = parse_cidr(raw_cidr) if isinstance(raw_cidr, str) else None
+    raw_name: Any = extract_field_value(obj, name_field)
+
+    return {
+        CmdbObjectKey.PUBLIC_ID: obj.get(CmdbObjectKey.PUBLIC_ID),
+        IpamTreeKey.NAME: raw_name if isinstance(raw_name, str) else None,
+        IpamTreeKey.CIDR: str(network) if network is not None else (raw_cidr if isinstance(raw_cidr, str) else None),
+        IpamTreeKey.TYPE: family,
+    }
+
+
+def subnet_tree_node(subnet_obj: dict[str, Any]) -> dict[str, Any]:
+    """
+    Shapes a SUBNET CmdbObject into a sidebar-tree node
+
+    Thin binding of ``_shape_tree_node`` to the SUBNET name / range fields with the family
+    resolved CIDR-first via ``subnet_family`` (selector fallback, IPv4 default)
+
+    Args:
+        subnet_obj (dict[str, Any]): The SUBNET CmdbObject document
+
+    Returns:
+        dict[str, Any]: One node with public_id, name, cidr and the address family under 'type'
+    """
+    return _shape_tree_node(
+        subnet_obj,
+        SubnetField.NAME,
+        SubnetField.NETWORK_RANGE,
+        subnet_family(subnet_obj),
+    )
+
+
+def _supernet_tree_node(
+    supernet_obj: dict[str, Any],
+    referenced_supernet_ids: set[int],
+) -> dict[str, Any]:
+    """
+    Shapes a SUPERNET CmdbObject into a sidebar-tree entry carrying 'has_children'
+
+    'has_children' is True when at least one SUBNET references the supernet via
+    'dg-supernet-ref', so the FE can render an expand caret without a probe request. The
+    subtree itself is fetched lazily via ``build_supernet_subnet_tree``
+
+    Args:
+        supernet_obj (dict[str, Any]): The SUPERNET CmdbObject document
+        referenced_supernet_ids (set[int]): Output of ``_collect_referenced_supernet_ids``
+
+    Returns:
+        dict[str, Any]: One entry with public_id, name, cidr, the address family under 'type'
+            and 'has_children'
+    """
+    node: dict[str, Any] = _shape_tree_node(
+        supernet_obj,
+        SupernetField.NAME,
+        SupernetField.NETWORK_RANGE,
+        supernet_family(supernet_obj),
+    )
+    node[IpamTreeKey.HAS_CHILDREN] = node[CmdbObjectKey.PUBLIC_ID] in referenced_supernet_ids
+
+    return node
+
+
+def _tree_sort_key(node: dict[str, Any]) -> tuple[int, int, int, int, str]:
+    """
+    Returns the sort key implementing the sidebar tree's display order
+
+    Order: IPv4 nodes before IPv6 nodes; within a family, nodes with a parsable 'cidr' sort
+    by ascending network address with prefix length as tiebreaker (so 10.0.0.0/8 precedes
+    10.0.0.0/16); nodes whose 'cidr' is missing or unparsable trail their family group,
+    ordered case-insensitively by name. The family rank reads the node's 'type' so unparsable
+    nodes still group under their selector-declared family
+
+    Args:
+        node (dict[str, Any]): A tree node shaped by ``_shape_tree_node``
+
+    Returns:
+        tuple[int, int, int, int, str]: (family rank, unparsable flag, network address,
+            prefix length, lowercase name)
+    """
+    family_rank: int = 1 if node.get(IpamTreeKey.TYPE) == IpAddressFamily.IPV6 else 0
+    cidr: Any = node.get(IpamTreeKey.CIDR)
+    network: Network | None = parse_cidr(cidr) if isinstance(cidr, str) else None
+
+    if network is None:
+        name: Any = node.get(IpamTreeKey.NAME)
+        return (family_rank, 1, 0, 0, name.lower() if isinstance(name, str) else '')
+
+    return (family_rank, 0, int(network.network_address), network.prefixlen, '')
+
+
+def sort_tree_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Returns a new list of tree nodes in the sidebar display order
+
+    Applies ``_tree_sort_key``: IPv4 before IPv6, ascending network address with prefix
+    length as tiebreaker within each family, unparsable-CIDR nodes trailing their family
+    ordered by name. Used for every flat block (supernets, unassigned) and the root level
+    of nested subtrees so the order rule is identical at every tree level
+
+    Args:
+        nodes (list[dict[str, Any]]): Tree nodes shaped by ``_shape_tree_node``
+
+    Returns:
+        list[dict[str, Any]]: The nodes in display order (input list is not mutated)
+    """
+    return sorted(nodes, key=_tree_sort_key)
+
+
+def nest_subnet_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Nests flat subnet nodes into a CIDR-containment tree and returns the root nodes
+
+    Every node is mutated in place to carry a 'children' list (empty for leaves). A node's
+    parent is the most-specific other node whose network strictly contains it - the same
+    semantics the supernet overview's ``sort_and_link_subnets`` applies - found with a single
+    stack pass over the nodes sorted by ascending network address and prefix length. Nodes of
+    different families can never link (strict containment treats them as disjoint) and nodes
+    with an equal CIDR become siblings. Nodes whose 'cidr' is missing or unparsable cannot
+    participate in containment and are returned as roots
+
+    Children inherit ascending CIDR order from the linking pass; the returned root list is
+    sorted via ``sort_tree_nodes`` so the family grouping and unparsable-trailing rules hold
+    at the top level too
+
+    Args:
+        nodes (list[dict[str, Any]]): Flat tree nodes shaped by ``_shape_tree_node``
+
+    Returns:
+        list[dict[str, Any]]: The root nodes in display order, each with nested 'children'
+    """
+    sortable: list[tuple[Network, dict[str, Any]]] = []
+    roots: list[dict[str, Any]] = []
+
+    for node in nodes:
+        node[IpamTreeKey.CHILDREN] = []
+        cidr: Any = node.get(IpamTreeKey.CIDR)
+        network: Network | None = parse_cidr(cidr) if isinstance(cidr, str) else None
+
+        if network is None:
+            roots.append(node)
+        else:
+            sortable.append((network, node))
+
+    sortable.sort(key=lambda item: (int(item[0].network_address), item[0].prefixlen))
+
+    stack: list[tuple[Network, dict[str, Any]]] = []
+
+    for network, node in sortable:
+        while stack and not is_strict_subnet(stack[-1][0], network):
+            stack.pop()
+
+        if stack:
+            stack[-1][1][IpamTreeKey.CHILDREN].append(node)
+        else:
+            roots.append(node)
+
+        stack.append((network, node))
+
+    return sort_tree_nodes(roots)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   DATA LOADING                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def load_all_special_type_objects(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    special_type: SpecialType,
+) -> list[dict[str, Any]]:
+    """
+    Returns every CmdbObject of the CmdbType marked with the given SpecialType
+
+    Returns an empty list when no CmdbType carries the SpecialType yet, so the tree renders
+    empty instead of erroring on a fresh installation
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        special_type (SpecialType): The SpecialType whose objects are loaded (SUPERNET / SUBNET)
+
+    Returns:
+        list[dict[str, Any]]: All CmdbObject documents of the resolved type
+    """
+    type_id: int | None = resolve_special_type_id(types_manager, special_type)
+
+    if type_id is None:
+        return []
+
+    return objects_manager.find_objects({CmdbObjectKey.TYPE_ID: type_id}, as_dict=True)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   ORCHESTRATOR                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def build_ipam_tree(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+) -> dict[str, Any]:
+    """
+    Builds the initial sidebar-tree payload: every supernet plus every unassigned subnet
+
+    One call covers the sidebar's first render. 'supernets' is the flat list of every
+    SUPERNET entry (public_id, name, cidr, type, has_children); the per-supernet subtrees
+    are fetched lazily via ``build_supernet_subnet_tree`` when the user expands an entry.
+    'unassigned' is the flat list of every SUBNET without a usable 'dg-supernet-ref'
+    (public_id, name, cidr, type) - standalone subnets carry no nesting (see module
+    docstring). Both blocks are sorted IPv4 before IPv6, then ascending by CIDR, with
+    unparsable-CIDR nodes trailing their family ordered by name
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+
+    Returns:
+        dict[str, Any]: {'supernets': [supernet entries], 'unassigned': [subnet nodes]}
+    """
+    supernet_objs: list[dict[str, Any]] = load_all_special_type_objects(
+        objects_manager, types_manager, SpecialType.SUPERNET,
+    )
+    subnet_objs: list[dict[str, Any]] = load_all_special_type_objects(
+        objects_manager, types_manager, SpecialType.SUBNET,
+    )
+
+    referenced: set[int] = _collect_referenced_supernet_ids(subnet_objs)
+
+    return {
+        IpamTreeKey.SUPERNETS: sort_tree_nodes(
+            [_supernet_tree_node(s, referenced) for s in supernet_objs],
+        ),
+        IpamTreeKey.UNASSIGNED: sort_tree_nodes(
+            [subnet_tree_node(s) for s in subnet_objs if _parent_supernet_id(s) is None],
+        ),
+    }
+
+
+def build_supernet_subnet_tree(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+    supernet_public_id: int,
+) -> dict[str, Any]:
+    """
+    Builds the full CIDR-nested subnet subtree of one supernet
+
+    Returns every SUBNET referencing the supernet (any nesting depth) as a nested node tree:
+    a node's parent is the most-specific sibling whose network strictly contains it, exactly
+    like the supernet overview view. The whole subtree comes back in one call - the hierarchy
+    is computed from CIDR containment over all subnets of the supernet anyway, so per-node
+    lazy loading would repeat the same work per expansion. A supernet without subnets returns
+    an empty 'children' list
+
+    Aborts with HTTP 404 when the supernet does not exist, HTTP 400 when the public_id refers
+    to a non-supernet CmdbObject or no SUPERNET CmdbType is defined
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+        supernet_public_id (int): public_id of the SUPERNET whose subtree is built
+
+    Returns:
+        dict[str, Any]: {'children': [root nodes, each with nested 'children']}
+    """
+    load_supernet_object(objects_manager, types_manager, supernet_public_id)
+
+    subnet_objs: list[dict[str, Any]] = load_subnets_for_supernet(
+        objects_manager, types_manager, supernet_public_id,
+    )
+
+    return {
+        IpamTreeKey.CHILDREN: nest_subnet_nodes([subnet_tree_node(s) for s in subnet_objs]),
+    }
+
+
+def build_unassigned_subnets(
+    objects_manager: ObjectsManager,
+    types_manager: TypesManager,
+) -> dict[str, Any]:
+    """
+    Builds the unassigned-subnets block alone, for targeted sidebar refreshes
+
+    Returns the same flat 'unassigned' list as ``build_ipam_tree`` - every SUBNET without a
+    usable 'dg-supernet-ref', sorted IPv4 before IPv6 then ascending by CIDR - without
+    reloading the supernet block. No nesting pass runs: standalone subnets are an
+    unstructured bucket
+
+    Args:
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes
+
+    Returns:
+        dict[str, Any]: {'unassigned': [subnet nodes]}
+    """
+    subnet_objs: list[dict[str, Any]] = load_all_special_type_objects(
+        objects_manager, types_manager, SpecialType.SUBNET,
+    )
+
+    return {
+        IpamTreeKey.UNASSIGNED: sort_tree_nodes(
+            [subnet_tree_node(s) for s in subnet_objs if _parent_supernet_id(s) is None],
+        ),
+    }

--- a/cmdb/interface/rest_api/init_rest_api.py
+++ b/cmdb/interface/rest_api/init_rest_api.py
@@ -253,6 +253,7 @@ def register_blueprints(app: BaseCmdbApp) -> None:
     from cmdb.interface.rest_api.routes.ipam_routes.ipam_supernet_routes import ipam_supernet_blueprint
     from cmdb.interface.rest_api.routes.ipam_routes.ipam_subnet_routes import ipam_subnet_blueprint
     from cmdb.interface.rest_api.routes.ipam_routes.ipam_assignable_routes import ipam_assignable_blueprint
+    from cmdb.interface.rest_api.routes.ipam_routes.ipam_tree_routes import ipam_tree_blueprint
 
     app.register_blueprint(auth_blueprint, url_prefix='/auth')
     app.register_blueprint(setup_blueprint, url_prefix='/setup')
@@ -315,6 +316,7 @@ def register_blueprints(app: BaseCmdbApp) -> None:
     app.register_blueprint(ipam_supernet_blueprint, url_prefix='/ipam/supernet')
     app.register_blueprint(ipam_subnet_blueprint, url_prefix='/ipam/subnet')
     app.register_blueprint(ipam_assignable_blueprint, url_prefix='/ipam/assignable-objects')
+    app.register_blueprint(ipam_tree_blueprint, url_prefix='/ipam/tree')
 
     # OpenCelium routes
     app.register_blueprint(oc_connectors_blueprint, url_prefix='/open_celium')

--- a/cmdb/interface/rest_api/routes/ipam_routes/ipam_subnet_routes.py
+++ b/cmdb/interface/rest_api/routes/ipam_routes/ipam_subnet_routes.py
@@ -17,13 +17,18 @@
 REST routes for SUBNET-centric IPAM views
 
 Exposes the subnet IP-Übersicht read-side payload that powers the per-subnet IP table view in
-the frontend, plus the bulk 'unassign IPs' write-side route that clears the subnet reference
-on one or more dg-ipam-interface rows. The IP table is paginated and supports an optional
-case-insensitive substring search against the canonical IP strings; the search filter does
-not affect the KPI block or the distributions
+the frontend, the per-sector drill-down, an Excel (.xlsx) export of the IP table, plus the bulk
+'unassign IPs' write-side route that clears the subnet reference on one or more dg-ipam-interface
+rows. The IP table is paginated and supports an optional case-insensitive substring search against
+the canonical IP strings; the search filter does not affect the KPI block or the distributions
+
+Also exposes the paginated subnet-options list backing the dg-ipam-interface subnet picker,
+filterable by address family ('type' query param) so the frontend can offer only subnets
+matching the family the user selected in the interface row
 """
 from logging import Logger, getLogger
 from typing import Any
+from datetime import datetime, timezone
 
 from flask import abort, request
 from werkzeug import Response
@@ -34,13 +39,22 @@ from cmdb.manager import ObjectsManager, TypesManager
 
 from cmdb.models.user_model import CmdbUser
 from cmdb.models.special_type_model.ipam_constants import (
+    IpAddressFamily,
     IpamPagination,
     IpamSearch,
     IpamOverviewKey,
     IpamUnassignKey,
+    IpamExport,
+    IpamSubnetIpsExport,
 )
-from cmdb.framework.ipam.subnet_overview import build_subnet_overview, build_invalid_subnet_overview
+from cmdb.framework.ipam.subnet_overview import (
+    build_subnet_overview,
+    build_invalid_subnet_overview,
+    build_subnet_sector_ips,
+)
+from cmdb.framework.ipam.subnet_options import build_subnet_options_page
 from cmdb.framework.ipam.subnet_unassign import unassign_ips_from_subnet
+from cmdb.framework.ipam.subnet_export import build_subnet_ips_xlsx
 from cmdb.interface.route_utils import insert_request_user, verify_api_access
 from cmdb.interface.rest_api.api_level_enum import ApiLevel
 from cmdb.interface.blueprints import APIBlueprint
@@ -50,6 +64,79 @@ from cmdb.interface.rest_api.responses import DefaultResponse
 LOGGER: Logger = getLogger(__name__)
 
 ipam_subnet_blueprint = APIBlueprint('ipam_subnet', __name__)
+
+
+@ipam_subnet_blueprint.route('/', methods=['GET'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def get_subnet_options(request_user: CmdbUser) -> Response:
+    """
+    HTTP `GET` route returning the paginated subnet-options list for the interface picker
+
+    Backs the dg-ipam-interface section's subnet reference dropdown: when the user selects an
+    address family in the interface row, the frontend reloads the options from this route with
+    the matching 'type' so only same-family subnets are offered. Each row carries the
+    lightweight node shape (public_id, name, cidr, address family under 'type'); rows are
+    sorted ascending by network address with prefix length as tiebreaker (IPv4 before IPv6 in
+    the unfiltered list), subnets with unparsable CIDRs trailing their family ordered by name.
+    The family of each subnet is resolved CIDR-first with the 'dg-subnet-type' selector as
+    fallback and IPv4 as legacy default, matching every other IPAM view
+
+    Query params:
+        type (str, optional): IpAddressFamily token ('ipv4' / 'ipv6') restricting the rows to
+            one family; absent or empty returns both families, any other value aborts 400
+        page (int, default=1): 1-based page number; clamped into the valid range server-side
+        page_size (int, default=50): page size; clamped into [1, 500] server-side
+        search (str, optional): case-insensitive substring filter against each subnet's name
+            and CIDR; empty / whitespace and queries shorter than IpamSearch.MIN_QUERY_LENGTH
+            are ignored, queries longer than IpamSearch.MAX_QUERY_LENGTH are truncated at the
+            route boundary
+
+    Args:
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: {'page', 'page_size', 'total', 'search', 'type',
+            'rows': [{public_id, name, cidr, type}, ...]}
+    """
+    try:
+        page: int = request.args.get(IpamOverviewKey.PAGE, default=1, type=int) or 1
+        page_size: int = (
+            request.args.get(IpamOverviewKey.PAGE_SIZE, default=IpamPagination.DEFAULT_PAGE_SIZE, type=int)
+            or IpamPagination.DEFAULT_PAGE_SIZE
+        )
+        raw_search: str = request.args.get(IpamOverviewKey.SEARCH, default='', type=str) or ''
+        search: str = raw_search[:IpamSearch.MAX_QUERY_LENGTH]
+        family: str = request.args.get(IpamOverviewKey.TYPE, default='', type=str) or ''
+
+        if family and not IpAddressFamily.is_valid(family):
+            abort(
+                400,
+                f"'{family}' is not a valid address family; allowed values:"
+                f" {IpAddressFamily.IPV4.value}, {IpAddressFamily.IPV6.value}!",
+            )
+
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        options: dict[str, Any] = build_subnet_options_page(
+            objects_manager,
+            types_manager,
+            page=page,
+            page_size=page_size,
+            search=search,
+            family=family,
+        )
+
+        return DefaultResponse(options).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[get_subnet_options] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(500, "An internal server error occured while loading the subnet options!")
 
 
 @ipam_subnet_blueprint.route('/overview/<int:public_id>', methods=['GET'])
@@ -148,36 +235,42 @@ def get_subnet_overview(public_id: int, request_user: CmdbUser) -> Response:
 @insert_request_user
 def unassign_ips_route(public_id: int, request_user: CmdbUser) -> Response:
     """
-    HTTP `POST` route that clears the subnet reference on one or more dg-ipam-interface rows
+    HTTP `POST` route that unassigns one or more dg-ipam-interface rows from the subnet
 
-    Each entry in the request's ``ips`` list identifies one currently-assigned IP of the
-    subnet; the route locates its owner CmdbObject, flips the row's ``dg-interface-subnet``
-    value to None and writes the owner back through ``ObjectsManager.update_object`` so ACL,
-    versioning and post-update hooks all run per-owner. The row itself stays on the owner
-    along with its IP and MAC values - only the subnet reference is cleared. Other interface
-    rows on the same owner (referencing other subnets or non-target IPs of the same subnet)
-    are left untouched
+    Each entry in the request's ``ips`` list identifies one currently-assigned IP of the subnet;
+    the route locates its owner CmdbObject(s) and applies the chosen ``mode`` to the matching
+    rows, then writes each owner back through ``ObjectsManager.update_object`` so ACL, versioning
+    and post-update hooks all run per-owner. The ``mode`` is a single selection for the whole
+    request (not per IP):
+      - 'reference' (default): flip the row's ``dg-interface-subnet`` value to None - the row, its
+        IP and MAC are kept; it is just detached from the subnet
+      - 'row': delete the whole matching dg-ipam-interface row (this edits the owner object to
+        drop the row; it does not delete the owner CmdbObject)
+    Other interface rows on the same owner (referencing other subnets or non-target IPs of the
+    same subnet) are left untouched
 
     Validate-all-or-nothing: if any requested IP is not currently assigned within the subnet,
     the route aborts 400 with the offending IPs and no write happens. Bad input shape (missing
-    list, empty list, non-string entry, non-canonical IPv4, IP outside the subnet) also aborts
-    400 before any database read. Aborts 404 when the subnet does not exist and 400 when the
-    public_id refers to a non-subnet object, no SUBNET CmdbType is defined, or the subnet's
-    network-range field is missing / unparsable
+    list, empty list, non-string entry, non-canonical IP, IP outside the subnet, unknown mode)
+    also aborts 400 before any database write. Aborts 404 when the subnet does not exist and 400
+    when the public_id refers to a non-subnet object, no SUBNET CmdbType is defined, or the
+    subnet's network-range field is missing / unparsable
 
     Body:
-        ips (list[str]): canonical IPv4 dotted-quad strings whose row should have its subnet
-            reference cleared; must be non-empty, each parseable, each within the subnet.
-            Duplicates are silently collapsed while preserving input order
+        ips (list[str]): canonical IPv4 / IPv6 strings to unassign; must be non-empty, each
+            parseable, each within the subnet. Duplicates are silently collapsed while preserving
+            input order
+        mode (str, optional): 'reference' (clear the subnet ref, default) or 'row' (delete the
+            whole row); applies to every IP in the request
 
     Args:
         public_id (int): public_id of the SUBNET CmdbObject to unassign rows from
         request_user (CmdbUser): CmdbUser making the request
 
     Returns:
-        Response: {'ips': [str, ...], 'unassigned_count': int}; 'ips' echoes the deduplicated
-            request order and 'unassigned_count' is the number of dg-ipam-interface rows
-            whose subnet reference was cleared across all touched owners
+        Response: {'ips': [str, ...], 'mode': str, 'unassigned_count': int}; 'ips' echoes the
+            deduplicated request order, 'mode' echoes the resolved mode and 'unassigned_count' is
+            the number of dg-ipam-interface rows affected across all touched owners
     """
     try:
         payload: dict[str, Any] = request.get_json(silent=True) or {}
@@ -191,6 +284,7 @@ def unassign_ips_route(public_id: int, request_user: CmdbUser) -> Response:
             public_id,
             payload.get(IpamUnassignKey.IPS),
             request_user,
+            raw_mode=payload.get(IpamUnassignKey.MODE),
         )
 
         return DefaultResponse(result).make_response()
@@ -204,6 +298,70 @@ def unassign_ips_route(public_id: int, request_user: CmdbUser) -> Response:
         abort(
             500,
             f"An internal server error occured while unassigning IPs from Subnet with ID: {public_id}!",
+        )
+
+
+@ipam_subnet_blueprint.route('/overview/<int:public_id>/sector', methods=['GET'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def get_subnet_sector_ips(public_id: int, request_user: CmdbUser) -> Response:
+    """
+    HTTP `GET` route returning the paginated IP list of a single IP-Verteilung sector
+
+    Backs the 'click a heatmap sector' drill-down: only the IPs of the clicked sector are loaded
+    instead of the whole subnet. The sector is identified by its start address (the ``ip_start``
+    the overview's ip_distribution emitted for that cell). For IPv4 the page lists the sector's
+    assignable addresses (free + assigned, network / broadcast excluded); for IPv6 it lists only
+    the assigned addresses inside the sector. Response carries just the 'ips' page block plus the
+    resolved sector range - the KPI block and distributions are not recomputed
+
+    Query params:
+        sector_start (str): The clicked sector's start address (its ip_start). Required
+        page (int, default=1): 1-based page number; clamped into the valid range server-side
+        page_size (int, default=50): page size; clamped into [1, 500] server-side
+
+    Args:
+        public_id (int): public_id of the SUBNET CmdbObject
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: {'sector': {ip_start, ip_end}, 'ips': {page, page_size, total, rows}}
+    """
+    try:
+        sector_start: str = request.args.get(IpamOverviewKey.SECTOR_START, default='', type=str) or ''
+
+        if not sector_start:
+            abort(400, "'sector_start' query parameter is required")
+
+        page: int = request.args.get(IpamOverviewKey.PAGE, default=1, type=int) or 1
+        page_size: int = (
+            request.args.get(IpamOverviewKey.PAGE_SIZE, default=IpamPagination.DEFAULT_PAGE_SIZE, type=int)
+            or IpamPagination.DEFAULT_PAGE_SIZE
+        )
+
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        result: dict[str, Any] = build_subnet_sector_ips(
+            objects_manager,
+            types_manager,
+            public_id,
+            sector_start,
+            page=page,
+            page_size=page_size,
+        )
+
+        return DefaultResponse(result).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[get_subnet_sector_ips] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(
+            500,
+            f"An internal server error occured while loading the sector IPs for Subnet with ID: {public_id}!",
         )
 
 
@@ -270,4 +428,55 @@ def get_invalid_subnet_overview(public_id: int, request_user: CmdbUser) -> Respo
             500,
             f"An internal server error occured while building the invalid-only overview"
             f" for Subnet with ID: {public_id}!",
+        )
+
+
+@ipam_subnet_blueprint.route('/overview/<int:public_id>/export', methods=['GET'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def export_subnet_ips(public_id: int, request_user: CmdbUser) -> Response:
+    """
+    HTTP `GET` route exporting a subnet's IP rows as an Excel (.xlsx) file
+
+    Returns the subnet's IP table as a single-sheet workbook with the columns IP, type, status,
+    assigned-to and MAC address. An IPv4 subnet exports all assignable addresses (free + assigned);
+    an IPv6 subnet exports only the assigned addresses. The file is returned as an attachment
+    download.
+
+    The export is capped at IpamSubnetIpsExport.MAX_EXPORT_ROWS rows: a subnet whose export would
+    exceed it aborts 400 ('too big') and no workbook is built. Aborts 404 when the subnet does not
+    exist and 400 when the public_id refers to a non-subnet object or the subnet's network range is
+    missing / unparsable
+
+    Args:
+        public_id (int): public_id of the SUBNET CmdbObject whose IPs are exported
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: The .xlsx workbook as an attachment download
+    """
+    try:
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        content: bytes = build_subnet_ips_xlsx(objects_manager, types_manager, public_id)
+
+        timestamp: str = datetime.now(timezone.utc).strftime('%Y_%m_%d-%H_%M_%S')
+        filename: str = IpamSubnetIpsExport.FILENAME_TEMPLATE.format(public_id=public_id, timestamp=timestamp)
+
+        return Response(
+            content,
+            mimetype=IpamExport.MIMETYPE,
+            headers={'Content-Disposition': f'attachment; filename={filename}'},
+        )
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[export_subnet_ips] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(
+            500,
+            f"An internal server error occured while exporting IPs for Subnet with ID: {public_id}!",
         )

--- a/cmdb/interface/rest_api/routes/ipam_routes/ipam_tree_routes.py
+++ b/cmdb/interface/rest_api/routes/ipam_routes/ipam_tree_routes.py
@@ -1,0 +1,160 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+REST routes for the IPAM sidebar tree
+
+Exposes the initial tree payload (every supernet plus every unassigned subnet in one call),
+the per-supernet subtree endpoint used to lazily expand one supernet entry into its full
+CIDR-nested subnet tree, and the unassigned-subnets endpoint for targeted refreshes of the
+'Unassigned' group. All payloads carry lightweight nodes (public_id, name, cidr, address
+family) sorted IPv4 before IPv6 and ascending by CIDR within each family
+"""
+from logging import Logger, getLogger
+from typing import Any
+
+from flask import abort
+from werkzeug import Response
+from werkzeug.exceptions import HTTPException
+
+from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
+from cmdb.manager import ObjectsManager, TypesManager
+
+from cmdb.models.user_model import CmdbUser
+from cmdb.framework.ipam.tree_overview import (
+    build_ipam_tree,
+    build_supernet_subnet_tree,
+    build_unassigned_subnets,
+)
+from cmdb.interface.route_utils import insert_request_user, verify_api_access
+from cmdb.interface.rest_api.api_level_enum import ApiLevel
+from cmdb.interface.blueprints import APIBlueprint
+from cmdb.interface.rest_api.responses import DefaultResponse
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER: Logger = getLogger(__name__)
+
+ipam_tree_blueprint = APIBlueprint('ipam_tree', __name__)
+
+
+@ipam_tree_blueprint.route('/', methods=['GET'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def get_ipam_tree(request_user: CmdbUser) -> Response:
+    """
+    HTTP `GET` route returning the initial sidebar-tree payload in one call
+
+    'supernets' lists every SUPERNET as a flat entry (public_id, name, cidr, type,
+    has_children); the subtree of an entry is fetched lazily via the per-supernet endpoint
+    when the user expands it. 'unassigned' lists every SUBNET without a parent supernet as a
+    flat node (public_id, name, cidr, type). Both blocks are sorted IPv4 before IPv6, then
+    ascending by CIDR with prefix length as tiebreaker; nodes with a missing or unparsable
+    CIDR trail their family group ordered by name
+
+    Args:
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: {'supernets': [supernet entries], 'unassigned': [subnet nodes]}
+    """
+    try:
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        tree: dict[str, Any] = build_ipam_tree(objects_manager, types_manager)
+
+        return DefaultResponse(tree).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[get_ipam_tree] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(500, "An internal server error occured while building the IPAM tree!")
+
+
+@ipam_tree_blueprint.route('/supernets/<int:public_id>', methods=['GET'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def get_supernet_subnet_tree(public_id: int, request_user: CmdbUser) -> Response:
+    """
+    HTTP `GET` route returning the full CIDR-nested subnet subtree of one supernet
+
+    Used by the frontend to populate one expanded supernet entry of the sidebar tree. Returns
+    every SUBNET referencing the supernet (any nesting depth) as a nested node tree in one
+    call; each node carries public_id, name, cidr, type and a 'children' list (empty for
+    leaves). Every 'children' array follows the IPv4-before-IPv6, ascending-CIDR order. A
+    supernet without subnets returns an empty 'children' list
+
+    Args:
+        public_id (int): public_id of the SUPERNET CmdbObject whose subtree is returned
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: {'children': [root nodes, each with nested 'children']}
+    """
+    try:
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        subtree: dict[str, Any] = build_supernet_subnet_tree(objects_manager, types_manager, public_id)
+
+        return DefaultResponse(subtree).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[get_supernet_subnet_tree] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(
+            500,
+            f"An internal server error occured while building the subnet tree for Supernet with ID: {public_id}!",
+        )
+
+
+@ipam_tree_blueprint.route('/unassigned', methods=['GET'])
+@verify_api_access(required_api_level=ApiLevel.LOCKED)
+@insert_request_user
+def get_unassigned_subnets(request_user: CmdbUser) -> Response:
+    """
+    HTTP `GET` route returning the unassigned-subnets block of the sidebar tree alone
+
+    Returns the same flat 'unassigned' list as the initial tree payload - every SUBNET whose
+    'dg-supernet-ref' is empty - without reloading the supernet block, for targeted refreshes
+    of the 'Unassigned' group. Nodes are sorted IPv4 before IPv6, then ascending by CIDR
+
+    Args:
+        request_user (CmdbUser): CmdbUser making the request
+
+    Returns:
+        Response: {'unassigned': [subnet nodes]}
+    """
+    try:
+        objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
+
+        unassigned: dict[str, Any] = build_unassigned_subnets(objects_manager, types_manager)
+
+        return DefaultResponse(unassigned).make_response()
+    except HTTPException as http_err:
+        raise http_err
+    except Exception as err:
+        LOGGER.error(
+            "[get_unassigned_subnets] Exception: %s. Type: %s",
+            err, type(err).__name__, exc_info=True,
+        )
+        abort(500, "An internal server error occured while loading the unassigned subnets!")

--- a/cmdb/interface/rest_api/routes/ipam_routes/ipam_validation_routes.py
+++ b/cmdb/interface/rest_api/routes/ipam_routes/ipam_validation_routes.py
@@ -31,6 +31,10 @@ from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
 from cmdb.manager import ObjectsManager, TypesManager
 
 from cmdb.models.user_model import CmdbUser
+from cmdb.models.special_type_model.ipam_constants import (
+    IpamValidationRequestKey,
+    IpamValidationResponseKey,
+)
 from cmdb.framework.ipam.subnet_validator import validate_subnet
 from cmdb.framework.ipam.supernet_validator import validate_supernet
 from cmdb.framework.ipam.vlan_validator import validate_vlan
@@ -79,12 +83,15 @@ def _build_validation_response(errors: list[dict[str, Any]]) -> dict[str, Any]:
     Returns:
         dict[str, Any]: {'valid': bool, 'errors': list[...]}
     """
-    return {'valid': not errors, 'errors': errors}
+    return {
+        IpamValidationResponseKey.VALID: not errors,
+        IpamValidationResponseKey.ERRORS: errors,
+    }
 
 
 def _parse_interface_rows_payload(
     raw_rows: list[Any],
-) -> list[tuple[int, int | None, str | None]]:
+) -> list[tuple[int, int | None, str | None, str | None]]:
     """
     Normalizes the inline `/validate/interface` row list into the tuple shape the batch
     validator expects
@@ -93,33 +100,39 @@ def _parse_interface_rows_payload(
     'row_index' fails the request because the response must echo the index back so the
     frontend can map errors to form rows. Missing / non-coercible 'subnet_id' or
     'ip_address' are treated as None — those rows still get cross-row dupe scrutiny but
-    are skipped by the per-row DB check, matching save-time semantics for incomplete rows
+    are skipped by the per-row DB check, matching save-time semantics for incomplete rows.
+    A missing / empty 'interface_type' is treated as None so the type-family consistency
+    check is skipped for that row, matching save-time semantics for legacy rows
 
     Args:
         raw_rows (list[Any]): The 'rows' field straight off the JSON payload
 
     Returns:
-        list[tuple[int, int | None, str | None]]: (row_index, subnet_ref, ip) tuples
+        list[tuple[int, int | None, str | None, str | None]]: (row_index, subnet_ref, ip,
+            interface_type) tuples
     """
-    rows: list[tuple[int, int | None, str | None]] = []
+    rows: list[tuple[int, int | None, str | None, str | None]] = []
 
     for index, raw in enumerate(raw_rows):
         if not isinstance(raw, dict):
             abort(400, f"rows[{index}] must be an object")
 
-        row_index_raw: Any = raw.get('row_index')
+        row_index_raw: Any = raw.get(IpamValidationRequestKey.ROW_INDEX)
 
         try:
             row_index: int = int(row_index_raw)
         except (TypeError, ValueError):
-            abort(400, f"rows[{index}].row_index is required and must be an integer")
+            abort(400, f"rows[{index}].{IpamValidationRequestKey.ROW_INDEX.value} is required and must be an integer")
 
-        subnet_ref: int | None = _coerce_optional_int(raw.get('subnet_id'))
+        subnet_ref: int | None = _coerce_optional_int(raw.get(IpamValidationRequestKey.SUBNET_ID))
 
-        ip_raw: Any = raw.get('ip_address')
+        ip_raw: Any = raw.get(IpamValidationRequestKey.IP_ADDRESS)
         ip_address: str | None = ip_raw if isinstance(ip_raw, str) and ip_raw else None
 
-        rows.append((row_index, subnet_ref, ip_address))
+        type_raw: Any = raw.get(IpamValidationRequestKey.INTERFACE_TYPE)
+        interface_type: str | None = type_raw if isinstance(type_raw, str) and type_raw else None
+
+        rows.append((row_index, subnet_ref, ip_address, interface_type))
 
     return rows
 
@@ -151,12 +164,12 @@ def validate_subnet_route(request_user: CmdbUser) -> Response:
     try:
         payload: dict[str, Any] = request.get_json(silent=True) or {}
 
-        network_range: Any = payload.get('network_range')
+        network_range: Any = payload.get(IpamValidationRequestKey.NETWORK_RANGE)
 
         if not isinstance(network_range, str) or not network_range:
             abort(400, "'network_range' is required and must be a string")
 
-        subnet_type: Any = payload.get('subnet_type')
+        subnet_type: Any = payload.get(IpamValidationRequestKey.SUBNET_TYPE)
 
         objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
         types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
@@ -165,8 +178,8 @@ def validate_subnet_route(request_user: CmdbUser) -> Response:
             objects_manager,
             types_manager,
             network_range=network_range,
-            parent_supernet_id=_coerce_optional_int(payload.get('parent_supernet_id')),
-            exclude_subnet_id=_coerce_optional_int(payload.get('exclude_subnet_id')),
+            parent_supernet_id=_coerce_optional_int(payload.get(IpamValidationRequestKey.PARENT_SUPERNET_ID)),
+            exclude_subnet_id=_coerce_optional_int(payload.get(IpamValidationRequestKey.EXCLUDE_SUBNET_ID)),
             subnet_type=subnet_type if isinstance(subnet_type, str) else None,
         )
 
@@ -202,12 +215,12 @@ def validate_supernet_route(request_user: CmdbUser) -> Response:  # pylint: disa
     try:
         payload: dict[str, Any] = request.get_json(silent=True) or {}
 
-        network_range: Any = payload.get('network_range')
+        network_range: Any = payload.get(IpamValidationRequestKey.NETWORK_RANGE)
 
         if not isinstance(network_range, str) or not network_range:
             abort(400, "'network_range' is required and must be a string")
 
-        supernet_type: Any = payload.get('supernet_type')
+        supernet_type: Any = payload.get(IpamValidationRequestKey.SUPERNET_TYPE)
 
         errors: list[dict[str, Any]] = validate_supernet(
             network_range=network_range,
@@ -241,7 +254,7 @@ def validate_vlan_route(request_user: CmdbUser) -> Response:
     try:
         payload: dict[str, Any] = request.get_json(silent=True) or {}
 
-        subnet_id: int | None = _coerce_optional_int(payload.get('subnet_id'))
+        subnet_id: int | None = _coerce_optional_int(payload.get(IpamValidationRequestKey.SUBNET_ID))
 
         if subnet_id is None:
             abort(400, "'subnet_id' is required and must be an integer")
@@ -277,8 +290,12 @@ def validate_interface_route(request_user: CmdbUser) -> Response:
               row_index (int): Position of the row in the MDS section
               subnet_id (int): The id of the subnet the row references
               ip_address (str): The interface IP
+              interface_type (str, optional): The row's 'dg-interface-type' selector
+                ('ipv4' / 'ipv6'); when supplied it is cross-checked against the IP's
+                address family and the referenced subnet's CIDR family
             Rows missing either subnet_id or ip_address are still accepted but skipped by the
-            per-row check (so a half-typed row does not produce noise)
+            per-row check (so a half-typed row does not produce noise); rows without
+            interface_type skip the type-family consistency check
         exclude_object_id (int, optional): Self-id when editing an existing object, so the
             object's own pre-edit rows are not flagged as collisions against the candidate
 
@@ -291,12 +308,12 @@ def validate_interface_route(request_user: CmdbUser) -> Response:
     try:
         payload: dict[str, Any] = request.get_json(silent=True) or {}
 
-        raw_rows: Any = payload.get('rows')
+        raw_rows: Any = payload.get(IpamValidationRequestKey.ROWS)
 
         if not isinstance(raw_rows, list):
             abort(400, "'rows' is required and must be a list of {row_index, subnet_id, ip_address}")
 
-        rows: list[tuple[int, int | None, str | None]] = _parse_interface_rows_payload(raw_rows)
+        rows: list[tuple[int, int | None, str | None, str | None]] = _parse_interface_rows_payload(raw_rows)
 
         objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
         types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
@@ -305,7 +322,7 @@ def validate_interface_route(request_user: CmdbUser) -> Response:
             objects_manager,
             types_manager,
             rows,
-            exclude_object_id=_coerce_optional_int(payload.get('exclude_object_id')),
+            exclude_object_id=_coerce_optional_int(payload.get(IpamValidationRequestKey.EXCLUDE_OBJECT_ID)),
         )
 
         return DefaultResponse(_build_validation_response(errors)).make_response()

--- a/cmdb/models/special_type_model/ipam_constants.py
+++ b/cmdb/models/special_type_model/ipam_constants.py
@@ -63,6 +63,7 @@ class InterfaceField(BaseStrEnum):
     SUBNET = 'dg-interface-subnet'
     IP = 'dg-interface-ip-address'
     MAC = 'dg-interface-mac-address'
+    TYPE = 'dg-interface-type'
 
 
 class IpAddressFamily(BaseStrEnum):
@@ -206,10 +207,52 @@ class IpamValidationDetailKey(BaseStrEnum):
     SUPERNET_TYPE = 'supernet_type'
     CIDR_FAMILY = 'cidr_family'
     SUPERNET_FAMILY = 'supernet_family'
+    INTERFACE_TYPE = 'interface_type'
+    IP_FAMILY = 'ip_family'
+    SUBNET_FAMILY = 'subnet_family'
 
     # Generic fall-throughs
     STORED_VALUE = 'stored_value'
     REFERENCES = 'references'
+
+
+class IpamValidationRequestKey(BaseStrEnum):
+    """
+    Request-body keys accepted by the IPAM pre-validation routes (/ipam/validate/*)
+
+    Names every JSON body field the four inline pre-check routes read, so route parsing and
+    the frontend stay aligned on field names. ROWS / ROW_INDEX / SUBNET_ID / IP_ADDRESS /
+    INTERFACE_TYPE / EXCLUDE_OBJECT_ID belong to the interface batch route; NETWORK_RANGE,
+    the two selector keys and the parent / exclusion ids belong to the subnet / supernet /
+    vlan candidate routes. Keys of the response envelope live in IpamValidationResponseKey,
+    keys inside an error's 'details' dict in IpamValidationDetailKey
+    """
+    # Subnet / supernet / vlan candidate routes
+    NETWORK_RANGE = 'network_range'
+    SUBNET_TYPE = 'subnet_type'
+    SUPERNET_TYPE = 'supernet_type'
+    SUBNET_ID = 'subnet_id'
+    PARENT_SUPERNET_ID = 'parent_supernet_id'
+    EXCLUDE_SUBNET_ID = 'exclude_subnet_id'
+
+    # Interface batch route
+    ROWS = 'rows'
+    ROW_INDEX = 'row_index'
+    IP_ADDRESS = 'ip_address'
+    INTERFACE_TYPE = 'interface_type'
+    EXCLUDE_OBJECT_ID = 'exclude_object_id'
+
+
+class IpamValidationResponseKey(BaseStrEnum):
+    """
+    Response-envelope keys returned by every IPAM pre-validation route (/ipam/validate/*)
+
+    VALID is the boolean summary flag (True when the error list is empty); ERRORS carries the
+    structured error list whose per-error keys are named in ValidationErrorKey and whose
+    'details' keys are named in IpamValidationDetailKey
+    """
+    VALID = 'valid'
+    ERRORS = 'errors'
 
 
 class IpamOverviewKey(BaseStrEnum):
@@ -291,6 +334,38 @@ class IpamOverviewKey(BaseStrEnum):
     USED_COUNT = 'used_count'
     TYPE_STATS = 'type_stats'
 
+    # Single-sector drill-down (subnet sector route): request param + response echo
+    SECTOR_START = 'sector_start'
+    SECTOR = 'sector'
+
+
+class IpamTreeKey(BaseStrEnum):
+    """
+    Output payload keys returned by the IPAM sidebar-tree routes
+
+    Names every dict key emitted to the frontend by the tree builders
+    (cmdb.framework.ipam.tree_overview). SUPERNETS and UNASSIGNED are the two blocks of the
+    initial tree payload: a flat list of every SUPERNET (each entry carrying HAS_CHILDREN so
+    the FE can render an expand caret without a probe request) and a flat list of every
+    SUBNET without a parent supernet. CHILDREN is the recursive nesting key of the
+    per-supernet subtree payload. The node-level keys (NAME, CIDR, TYPE, HAS_CHILDREN) are
+    scoped here even where their string values coincide with IpamOverviewKey members because
+    the tree nodes form their own wire schema: TYPE carries the node's address family
+    (IpAddressFamily token), unlike the overview routes where 'type' is a type-filter query
+    parameter. The node's 'public_id' key is CmdbObjectKey.PUBLIC_ID, matching the overview
+    rows
+    """
+    # Envelope blocks of the tree payloads
+    SUPERNETS = 'supernets'
+    UNASSIGNED = 'unassigned'
+    CHILDREN = 'children'
+
+    # Per-node fields
+    NAME = 'name'
+    CIDR = 'cidr'
+    TYPE = 'type'
+    HAS_CHILDREN = 'has_children'
+
 
 class IpamRowStatus(BaseStrEnum):
     """
@@ -310,15 +385,32 @@ class IpamUnassignKey(BaseStrEnum):
 
     SUBNET_IDS is the request-body field of the supernet route carrying the list of subnet
     public_ids the caller asks to detach from the supernet. IPS is the request-body field of
-    the subnet route carrying the list of canonical IPv4 strings whose dg-ipam-interface rows
-    should be removed from their owner CmdbObjects. UNASSIGNED_COUNT is the response field
-    echoing how many entries the route actually cleared. All three are scoped to the unassign
+    the subnet route carrying the list of canonical IP strings whose dg-ipam-interface rows
+    should be unassigned from their owner CmdbObjects. MODE is the optional request-body field
+    of the subnet route selecting whether to clear the subnet reference or delete the whole row
+    (see IpamUnassignMode); it is also echoed in the response. UNASSIGNED_COUNT is the response
+    field echoing how many rows the route actually affected. All four are scoped to the unassign
     routes alone - keys shared with the read-side overview payload live in IpamOverviewKey
     instead
     """
     SUBNET_IDS = 'subnet_ids'
     IPS = 'ips'
+    MODE = 'mode'
     UNASSIGNED_COUNT = 'unassigned_count'
+
+
+class IpamUnassignMode(BaseStrEnum):
+    """
+    Allowed values of the subnet unassign route's 'mode' field
+
+    REFERENCE clears only the dg-interface-subnet reference on each matching dg-ipam-interface
+    row (the row, its IP and MAC are kept; the row is just detached from the subnet). ROW deletes
+    the whole matching row from its owner object. The mode applies to every IP in one request -
+    it is not chosen per row. REFERENCE is the default when the field is omitted, preserving the
+    original behaviour
+    """
+    REFERENCE = 'reference'
+    ROW = 'row'
 
 
 class IpamBucketLabel(BaseStrEnum):
@@ -396,3 +488,21 @@ class IpamExport:
     IP_RANGE_SEPARATOR: str = ' - '
     MIMETYPE: str = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     FILENAME_TEMPLATE: str = 'supernet_{public_id}_subnets_{timestamp}.xlsx'
+
+
+class IpamSubnetIpsExport:
+    """
+    Constants for the subnet 'IP overview' Excel (.xlsx) export
+
+    SHEET_TITLE names the single worksheet; HEADERS is the ordered column row, identical for both
+    address families (the family difference is which rows are emitted, not which columns). The
+    columns mirror the overview IP table: the address, its type label, its status, the assigned
+    owner's summary line and its MAC. MAX_EXPORT_ROWS caps how many IP rows may be exported - an
+    export that would exceed it is rejected (HTTP 400) and no workbook is built; the counted volume
+    is the IPv4 assignable count (free + assigned) or the IPv6 assigned count. FILENAME_TEMPLATE
+    builds the download filename. The OpenXML content type is shared via IpamExport.MIMETYPE
+    """
+    SHEET_TITLE: str = 'Subnet IPs'
+    HEADERS: list[str] = ['IP', 'Type', 'Status', 'Assigned To', 'MAC Address']
+    MAX_EXPORT_ROWS: int = 2500
+    FILENAME_TEMPLATE: str = 'subnet_{public_id}_ips_{timestamp}.xlsx'

--- a/cmdb/models/special_type_model/schemas/__init__.py
+++ b/cmdb/models/special_type_model/schemas/__init__.py
@@ -13,3 +13,13 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Predefined CmdbType schemas for the IPAM SpecialTypes
+
+Each schema module exposes a get_<special_type>_schema() builder returning the ready-to-use
+CmdbType schema dict (sections, fields, the 'special_type' marker) for one SpecialType;
+SchemaProvider maps a SpecialType value to the matching builder for the special-type creation
+route and the DataGerry assistant. cidr_regex holds the coarse field-level IP / CIDR
+validation patterns shared by the SUBNET and SUPERNET schemas and the dg-ipam-interface
+section template
+"""

--- a/cmdb/models/special_type_model/schemas/cidr_regex.py
+++ b/cmdb/models/special_type_model/schemas/cidr_regex.py
@@ -17,10 +17,10 @@
 Shared IP validation regexes used by the IPAM schemas and section templates
 
 CIDR_REGEX matches a network range (address plus '/prefix'); IP_ADDRESS_REGEX matches a bare host
-address. Both accept either IPv4 or IPv6. These are coarse field-level guards only - the canonical
-validation (host-bits-zero, family-specific semantics) is done in code via the ipaddress module in
-cmdb.framework.ipam.cidr. Note: the IPAM processing layer (cidr.py, validators, overviews) is still
-IPv4-only, so an IPv6 value passes these regexes but is not yet processed as IPv6 downstream
+address. Both accept either IPv4 or IPv6, matching the downstream IPAM processing layer (cidr.py,
+validators, overviews), which handles both families. These are coarse field-level guards only -
+the canonical validation (host-bits-zero, family-specific semantics) is done in code via the
+ipaddress module in cmdb.framework.ipam.cidr
 """
 # -------------------------------------------------------------------------------------------------------------------- #
 

--- a/cmdb/models/special_type_model/special_type_enum.py
+++ b/cmdb/models/special_type_model/special_type_enum.py
@@ -14,23 +14,44 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-Implementation of all available SpecialTypes
+The SpecialType enum: CmdbType flavours that carry framework-level IPAM behaviour
+
+A CmdbType marks itself as a SpecialType via its schema's 'special_type' key. On creation
+such a type receives its predefined schema (see cmdb.models.special_type_model.schemas) and
+the IPAM cross-wiring (reference fields, dg-ipam-interface template; see
+cmdb.framework.ipam.special_type_wiring). The enum extends BaseStrEnum so members are
+interchangeable with their string values for dict lookup, equality and JSON serialization
 """
-from typing import Any, Iterable
+from typing import Iterable
 
 from cmdb.utils import BaseStrEnum
 # -------------------------------------------------------------------------------------------------------------------- #
 
 class SpecialType(BaseStrEnum):
-    """Types of Events"""
+    """
+    The available SpecialType tokens stored under a CmdbType schema's 'special_type' key
+
+    At most one CmdbType per member may exist in an installation - the special-type creation
+    route only offers members not yet claimed (see ``get_unused_types``). The string values
+    are the wire-format tokens exchanged with the frontend
+    """
     SUPERNET = 'SUPERNET'
     SUBNET = 'SUBNET'
     VLAN = 'VLAN'
 
 
     @classmethod
-    def get_special_types(cls) -> dict[str, Any]:
-        """TODO: document"""
+    def get_special_types(cls) -> dict[str, str]:
+        """
+        Returns every SpecialType member mapped to its user-facing display label
+
+        Backs the special-type listing route when existing special types are not filtered
+        out; the labels are the fixed English strings the frontend shows in the creation
+        dialog
+
+        Returns:
+            dict[str, str]: {member: display label} for every member of the enum
+        """
         return {
             cls.SUPERNET: "IPAM - Supernet class",
             cls.SUBNET: "IPAM - Subnet class",
@@ -39,11 +60,22 @@ class SpecialType(BaseStrEnum):
 
 
     @classmethod
-    def get_unused_types(cls, existing: Iterable[str]) -> dict[str, Any]:
-        """TODO: dcoument"""
+    def get_unused_types(cls, existing: Iterable[str]) -> dict[str, str]:
+        """
+        Returns the SpecialTypes not yet claimed by an existing CmdbType, with display labels
+
+        Drives the special-type creation dialog: each SpecialType may exist at most once, so
+        members whose value appears in ``existing`` are omitted from the result
+
+        Args:
+            existing (Iterable[str]): SpecialType values already claimed by existing CmdbTypes
+
+        Returns:
+            dict[str, str]: {member: display label} for every member not in ``existing``
+        """
         existing_set: set[str] = set(existing)
 
-        unused_types: dict[str, Any] = {
+        unused_types: dict[str, str] = {
             key: value
             for key, value in cls.get_special_types().items()
             if key not in existing_set

--- a/tests/integration/framework/test_integration_ipam_ipv6.py
+++ b/tests/integration/framework/test_integration_ipam_ipv6.py
@@ -27,13 +27,22 @@ A SUPERNET + SUBNET + carrier CmdbType and one IPv6 supernet / subnet / interfac
 seeded directly into the collections; the framework helpers then run against that real data.
 """
 from datetime import datetime, timezone
+from io import BytesIO
 from typing import Any
 
 import pytest
+from openpyxl import load_workbook
 
 from cmdb.database import MongoDatabaseManager
 from cmdb.manager import ObjectsManager, TypesManager
-from cmdb.models.object_model import CmdbObject, CmdbObjectKey, extract_field_value
+from cmdb.models.object_model import (
+    CmdbObject,
+    CmdbObjectKey,
+    CmdbObjectFieldKey,
+    CmdbObjectMdsKey,
+    CmdbObjectMdsRowKey,
+    extract_field_value,
+)
 from cmdb.models.type_model import CmdbType
 from cmdb.models.special_type_model.ipam_constants import (
     SupernetField,
@@ -43,10 +52,16 @@ from cmdb.models.special_type_model.ipam_constants import (
     IpamOverviewKey,
     IpamBucketLabel,
     IpAddressFamily,
+    IpamRowStatus,
+    IpamUnassignKey,
+    IpamUnassignMode,
+    IpamSubnetIpsExport,
 )
 from cmdb.framework.ipam.subnet_validator import SubnetErrorCode, validate_subnet
 from cmdb.framework.ipam.supernet_overview import build_supernet_overview
-from cmdb.framework.ipam.subnet_overview import build_subnet_overview
+from cmdb.framework.ipam.subnet_overview import build_subnet_overview, build_subnet_sector_ips
+from cmdb.framework.ipam.subnet_unassign import unassign_ips_from_subnet
+from cmdb.framework.ipam.subnet_export import build_subnet_ips_xlsx
 from cmdb.framework.ipam.enforcement import enforce_object_invariants
 from cmdb.utils import ValidationErrorKey
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -59,13 +74,18 @@ SUPERNET_ID: int = 9420
 SUBNET_ID: int = 9421
 CARRIER_ID: int = 9422
 CANON_SUBNET_ID: int = 9423
+UNASSIGN_REF_OWNER_ID: int = 9430
+UNASSIGN_ROW_OWNER_ID: int = 9431
 
 SUPERNET_RANGE_V6: str = '2001:db8::/48'
 SUBNET_RANGE_V6: str = '2001:db8:0:1::/64'
 ASSIGNED_IP_V6: str = '2001:db8:0:1::5'
 
 TYPE_IDS: list[int] = [SUPERNET_TYPE_ID, SUBNET_TYPE_ID, CARRIER_TYPE_ID]
-OBJECT_IDS: list[int] = [SUPERNET_ID, SUBNET_ID, CARRIER_ID, CANON_SUBNET_ID]
+OBJECT_IDS: list[int] = [
+    SUPERNET_ID, SUBNET_ID, CARRIER_ID, CANON_SUBNET_ID,
+    UNASSIGN_REF_OWNER_ID, UNASSIGN_ROW_OWNER_ID,
+]
 
 
 def _type_doc(public_id: int, name: str, label: str, special_type: str | None) -> dict[str, Any]:
@@ -111,6 +131,17 @@ def _object_doc(public_id: int, type_id: int, fields: list[dict[str, Any]],
         doc['multi_data_sections'] = mds
 
     return doc
+
+
+def _interface_carrier(owner_id: int, ip: str) -> dict[str, Any]:
+    """Builds a carrier object with one dg-ipam-interface row referencing the test subnet at ``ip``."""
+    return _object_doc(owner_id, CARRIER_TYPE_ID, [_field('dg-name', f'host-{owner_id}')], mds=[{
+        CmdbObjectMdsKey.SECTION_ID: IpamSection.INTERFACE,
+        CmdbObjectMdsKey.VALUES: [{CmdbObjectMdsRowKey.DATA: [
+            _field(InterfaceField.SUBNET, SUBNET_ID),
+            _field(InterfaceField.IP, ip),
+        ]}],
+    }])
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -219,6 +250,21 @@ def test_subnet_overview_ipv6_is_assigned_only_with_null_percentages(
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
+#                                          SECTOR DRILL-DOWN (IPv6)                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_subnet_sector_ipv6_returns_only_assigned_ips_in_the_window(
+    objects_manager: ObjectsManager, types_manager: TypesManager,
+) -> None:
+    """Drilling into the first sector of the IPv6 /64 returns only its assigned address, from real Mongo"""
+    payload = build_subnet_sector_ips(objects_manager, types_manager, SUBNET_ID, '2001:db8:0:1::')
+
+    assert payload[IpamOverviewKey.SECTOR][IpamOverviewKey.IP_START] == '2001:db8:0:1::'
+    ips_block = payload[IpamOverviewKey.IPS]
+    assert ips_block[IpamOverviewKey.TOTAL] == 1
+    assert [r[IpamOverviewKey.IP] for r in ips_block[IpamOverviewKey.ROWS]] == [ASSIGNED_IP_V6]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
 #                                            SUBNET VALIDATION (IPv6)                                                  #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_validate_subnet_ipv6_candidate_inside_ipv6_supernet_is_valid(
@@ -244,6 +290,78 @@ def test_validate_subnet_ipv4_candidate_under_ipv6_supernet_is_family_mismatch(
 
     codes = {e[ValidationErrorKey.CODE] for e in errors}
     assert SubnetErrorCode.PARENT_SUPERNET_FAMILY_MISMATCH in codes
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          UNASSIGN MODES (IPv6, real Mongo)                                           #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_unassign_reference_mode_clears_subnet_ref_against_mongo(
+    objects_manager: ObjectsManager, types_manager: TypesManager,
+    database_manager: MongoDatabaseManager, database_name: str, full_access_user,
+) -> None:
+    """reference mode finds the owner via the real interface query, clears the ref, and keeps the row"""
+    objects = database_manager.get_collection(CmdbObject.COLLECTION, database_name)
+    objects.insert_one(_interface_carrier(UNASSIGN_REF_OWNER_ID, '2001:db8:0:1::6'))
+
+    try:
+        result = unassign_ips_from_subnet(
+            objects_manager, types_manager, SUBNET_ID, ['2001:db8:0:1::6'], full_access_user,
+            raw_mode='reference',
+        )
+
+        assert result[IpamUnassignKey.MODE] == IpamUnassignMode.REFERENCE
+        assert result[IpamUnassignKey.UNASSIGNED_COUNT] == 1
+
+        stored = objects.find_one({CmdbObjectKey.PUBLIC_ID: UNASSIGN_REF_OWNER_ID})
+        row_data = stored[CmdbObjectKey.MULTI_DATA_SECTIONS][0][CmdbObjectMdsKey.VALUES][0][CmdbObjectMdsRowKey.DATA]
+        subnet_entry = next(e for e in row_data if e[CmdbObjectFieldKey.NAME] == InterfaceField.SUBNET)
+        assert subnet_entry[CmdbObjectFieldKey.VALUE] is None  # ref cleared, the row (IP) is kept
+    finally:
+        objects.delete_one({CmdbObjectKey.PUBLIC_ID: UNASSIGN_REF_OWNER_ID})
+
+
+def test_unassign_row_mode_deletes_the_interface_row_against_mongo(
+    objects_manager: ObjectsManager, types_manager: TypesManager,
+    database_manager: MongoDatabaseManager, database_name: str, full_access_user,
+) -> None:
+    """row mode deletes the whole matching dg-ipam-interface row from the owner, persisted to Mongo"""
+    objects = database_manager.get_collection(CmdbObject.COLLECTION, database_name)
+    objects.insert_one(_interface_carrier(UNASSIGN_ROW_OWNER_ID, '2001:db8:0:1::7'))
+
+    try:
+        result = unassign_ips_from_subnet(
+            objects_manager, types_manager, SUBNET_ID, ['2001:db8:0:1::7'], full_access_user,
+            raw_mode='row',
+        )
+
+        assert result[IpamUnassignKey.MODE] == IpamUnassignMode.ROW
+        assert result[IpamUnassignKey.UNASSIGNED_COUNT] == 1
+
+        stored = objects.find_one({CmdbObjectKey.PUBLIC_ID: UNASSIGN_ROW_OWNER_ID})
+        # the interface section survives but its single row was removed (owner object kept)
+        assert stored[CmdbObjectKey.MULTI_DATA_SECTIONS][0][CmdbObjectMdsKey.VALUES] == []
+    finally:
+        objects.delete_one({CmdbObjectKey.PUBLIC_ID: UNASSIGN_ROW_OWNER_ID})
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                       SUBNET IP EXPORT (IPv6, real Mongo)                                            #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_build_subnet_ips_xlsx_ipv6_exports_assigned_only_against_mongo(
+    objects_manager: ObjectsManager, types_manager: TypesManager,
+) -> None:
+    """The IPv6 subnet export runs the real assigned-rows query and emits only the assigned IP row"""
+    content: bytes = build_subnet_ips_xlsx(objects_manager, types_manager, SUBNET_ID)
+
+    sheet = load_workbook(BytesIO(content)).active
+    rows: list[tuple[Any, ...]] = list(sheet.iter_rows(values_only=True))
+
+    assert sheet.title == IpamSubnetIpsExport.SHEET_TITLE
+    assert rows[0] == tuple(IpamSubnetIpsExport.HEADERS)
+    # IPv6 exports assigned addresses only: the seeded carrier at ::5 is the single data row
+    assert len(rows) == 2
+    assert rows[1][0] == ASSIGNED_IP_V6
+    assert rows[1][2] == IpamRowStatus.ASSIGNED
 
 
 # -------------------------------------------------------------------------------------------------------------------- #

--- a/tests/unit/framework/ipam/test_cidr.py
+++ b/tests/unit/framework/ipam/test_cidr.py
@@ -28,8 +28,9 @@ from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 import pytest
 
 from cmdb.utils import ValidationErrorKey
-from cmdb.models.special_type_model.ipam_constants import IpamValidationDetailKey
+from cmdb.models.special_type_model.ipam_constants import IpAddressFamily, IpamValidationDetailKey
 from cmdb.framework.ipam.cidr import (
+    address_family,
     parse_cidr,
     parse_ip,
     contains,
@@ -426,7 +427,7 @@ def test_validate_canonical_cidr_value_returns_network_and_no_errors_for_canonic
     network, errors = validate_canonical_cidr_value('10.0.0.0/24', SAMPLE_ERROR_CODE)
 
     assert network == IPv4Network('10.0.0.0/24')
-    assert errors == []
+    assert not errors
 
 
 @pytest.mark.parametrize('invalid_value', [
@@ -470,3 +471,16 @@ def test_validate_canonical_cidr_value_uses_caller_supplied_error_code() -> None
 
     assert first_errors[0][ValidationErrorKey.CODE] == 'code_a'
     assert second_errors[0][ValidationErrorKey.CODE] == 'code_b'
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                  address_family                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_address_family_returns_ipv4_for_ipv4_address() -> None:
+    """A parsed IPv4 address maps to the IpAddressFamily.IPV4 token"""
+    assert address_family(parse_ip('10.0.0.5')) == IpAddressFamily.IPV4
+
+
+def test_address_family_returns_ipv6_for_ipv6_address() -> None:
+    """A parsed IPv6 address maps to the IpAddressFamily.IPV6 token"""
+    assert address_family(parse_ip('2001:db8::5')) == IpAddressFamily.IPV6

--- a/tests/unit/framework/ipam/test_enforcement.py
+++ b/tests/unit/framework/ipam/test_enforcement.py
@@ -118,8 +118,12 @@ def _make_field(name: Any, value: Any) -> dict[str, Any]:
     return {CmdbObjectFieldKey.NAME: name, CmdbObjectFieldKey.VALUE: value}
 
 
-def _make_interface_row(subnet_id: int | None, ip: str | None) -> dict[str, Any]:
-    """Builds one MDS interface row."""
+def _make_interface_row(
+    subnet_id: int | None,
+    ip: str | None,
+    interface_type: str | None = None,
+) -> dict[str, Any]:
+    """Builds one MDS interface row with an optional dg-interface-type entry."""
     data: list[dict[str, Any]] = []
 
     if subnet_id is not None:
@@ -127,6 +131,9 @@ def _make_interface_row(subnet_id: int | None, ip: str | None) -> dict[str, Any]
 
     if ip is not None:
         data.append(_make_field(InterfaceField.IP, ip))
+
+    if interface_type is not None:
+        data.append(_make_field(InterfaceField.TYPE, interface_type))
 
     return {CmdbObjectMdsRowKey.DATA: data}
 
@@ -256,7 +263,7 @@ def test_extract_interface_rows_returns_empty_when_no_mds_sections() -> None:
     """An object with no multi_data_sections list yields no rows"""
     obj = _make_object_doc(CANDIDATE_OBJECT_ID, OTHER_TYPE_ID)
 
-    assert _extract_interface_rows(obj) == []
+    assert not _extract_interface_rows(obj)
 
 
 def test_extract_interface_rows_skips_non_interface_sections() -> None:
@@ -268,7 +275,7 @@ def test_extract_interface_rows_skips_non_interface_sections() -> None:
         },
     ])
 
-    assert _extract_interface_rows(obj) == []
+    assert not _extract_interface_rows(obj)
 
 
 def test_extract_interface_rows_returns_subnet_and_ip_for_complete_row() -> None:
@@ -277,7 +284,7 @@ def test_extract_interface_rows_returns_subnet_and_ip_for_complete_row() -> None
         _make_interface_section([_make_interface_row(SIBLING_SUBNET_ID, '10.0.0.5')]),
     ])
 
-    assert _extract_interface_rows(obj) == [(0, SIBLING_SUBNET_ID, '10.0.0.5')]
+    assert _extract_interface_rows(obj) == [(0, SIBLING_SUBNET_ID, '10.0.0.5', None)]
 
 
 def test_extract_interface_rows_yields_none_pair_for_empty_row() -> None:
@@ -286,7 +293,7 @@ def test_extract_interface_rows_yields_none_pair_for_empty_row() -> None:
         _make_interface_section([{CmdbObjectMdsRowKey.DATA: []}]),
     ])
 
-    assert _extract_interface_rows(obj) == [(0, None, None)]
+    assert _extract_interface_rows(obj) == [(0, None, None, None)]
 
 
 def test_extract_interface_rows_treats_empty_string_ip_as_none() -> None:
@@ -295,7 +302,27 @@ def test_extract_interface_rows_treats_empty_string_ip_as_none() -> None:
         _make_interface_section([_make_interface_row(SIBLING_SUBNET_ID, '')]),
     ])
 
-    assert _extract_interface_rows(obj) == [(0, SIBLING_SUBNET_ID, None)]
+    assert _extract_interface_rows(obj) == [(0, SIBLING_SUBNET_ID, None, None)]
+
+
+def test_extract_interface_rows_passes_interface_type_token_through() -> None:
+    """A non-empty dg-interface-type value lands in the tuple's fourth slot verbatim"""
+    obj = _make_object_doc(CANDIDATE_OBJECT_ID, OTHER_TYPE_ID, mds=[
+        _make_interface_section([
+            _make_interface_row(SIBLING_SUBNET_ID, '10.0.0.5', interface_type=IpAddressFamily.IPV4),
+        ]),
+    ])
+
+    assert _extract_interface_rows(obj) == [(0, SIBLING_SUBNET_ID, '10.0.0.5', IpAddressFamily.IPV4)]
+
+
+def test_extract_interface_rows_treats_empty_string_type_as_none() -> None:
+    """An empty dg-interface-type value is normalized to None so the family check is skipped"""
+    obj = _make_object_doc(CANDIDATE_OBJECT_ID, OTHER_TYPE_ID, mds=[
+        _make_interface_section([_make_interface_row(SIBLING_SUBNET_ID, '10.0.0.5', interface_type='')]),
+    ])
+
+    assert _extract_interface_rows(obj) == [(0, SIBLING_SUBNET_ID, '10.0.0.5', None)]
 
 
 def test_extract_interface_rows_preserves_row_indices_in_order() -> None:
@@ -364,7 +391,7 @@ def test_enforce_subnet_object_on_insert_runs_validate_subnet() -> None:
     with patch(f'{ENF_PATH}.validate_subnet', return_value=[]) as validate_mock:
         errors = _enforce_subnet_object(MagicMock(), MagicMock(), candidate, previous_object=None)
 
-    assert errors == []
+    assert not errors
     validate_mock.assert_called_once()
     assert validate_mock.call_args.kwargs['exclude_subnet_id'] is None
 
@@ -392,7 +419,7 @@ def test_enforce_subnet_object_allows_range_change_even_when_interface_ips_would
     with patch(f'{ENF_PATH}.validate_subnet', return_value=[]) as validate_mock:
         errors = _enforce_subnet_object(MagicMock(), MagicMock(), candidate, previous_object=previous)
 
-    assert errors == []
+    assert not errors
     validate_mock.assert_called_once()
 
 
@@ -427,7 +454,7 @@ def test_enforce_supernet_object_returns_empty_for_canonical_cidr_without_type()
     """A canonical CIDR with no type selector passes (the family check is skipped)"""
     candidate = _make_supernet_candidate(CANDIDATE_OBJECT_ID, NEW_RANGE)
 
-    assert _enforce_supernet_object(candidate) == []
+    assert not _enforce_supernet_object(candidate)
 
 
 def test_enforce_supernet_object_returns_empty_when_type_matches_cidr_family() -> None:
@@ -435,8 +462,8 @@ def test_enforce_supernet_object_returns_empty_when_type_matches_cidr_family() -
     ipv4 = _make_supernet_candidate(CANDIDATE_OBJECT_ID, NEW_RANGE, supernet_type=IpAddressFamily.IPV4)
     ipv6 = _make_supernet_candidate(CANDIDATE_OBJECT_ID, '2001:db8::/32', supernet_type=IpAddressFamily.IPV6)
 
-    assert _enforce_supernet_object(ipv4) == []
-    assert _enforce_supernet_object(ipv6) == []
+    assert not _enforce_supernet_object(ipv4)
+    assert not _enforce_supernet_object(ipv6)
 
 
 def test_enforce_supernet_object_emits_type_family_mismatch_when_selector_disagrees() -> None:
@@ -457,7 +484,7 @@ def test_enforce_supernet_object_allows_range_change_even_when_child_subnets_wou
     """
     candidate = _make_supernet_candidate(CANDIDATE_OBJECT_ID, NEW_RANGE)
 
-    assert _enforce_supernet_object(candidate) == []
+    assert not _enforce_supernet_object(candidate)
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -470,7 +497,7 @@ def test_enforce_vlan_object_returns_empty_when_no_subnet_ref_present() -> None:
     with patch(f'{ENF_PATH}.validate_vlan') as validate_mock:
         errors = _enforce_vlan_object(MagicMock(), MagicMock(), candidate)
 
-    assert errors == []
+    assert not errors
     validate_mock.assert_not_called()
 
 
@@ -500,7 +527,7 @@ def test_enforce_interface_rows_returns_empty_when_no_rows_present() -> None:
     with patch(f'{ENF_PATH}.validate_interface_rows') as validate_mock:
         errors = _enforce_interface_rows(MagicMock(), MagicMock(), candidate, previous_object=None)
 
-    assert errors == []
+    assert not errors
     validate_mock.assert_not_called()
 
 
@@ -585,7 +612,7 @@ def test_enforce_object_invariants_canonicalizes_ipv6_range_before_save() -> Non
     with patch(f'{ENF_PATH}._resolve_object_special_type', return_value=SpecialType.SUBNET):
         errors = enforce_object_invariants(MagicMock(), MagicMock(), candidate)
 
-    assert errors == []
+    assert not errors
     assert extract_field_value(candidate, SubnetField.NETWORK_RANGE) == '2001:db8::/32'
 
 
@@ -597,7 +624,7 @@ def test_guard_supernet_delete_returns_empty_when_no_subnets_reference_it() -> N
     with patch(f'{ENF_PATH}.find_subnets_referencing_supernet', return_value=[]):
         errors = _guard_supernet_delete(MagicMock(), MagicMock(), PARENT_SUPERNET_ID)
 
-    assert errors == []
+    assert not errors
 
 
 def test_guard_supernet_delete_returns_guard_error_when_subnets_reference_it() -> None:
@@ -621,7 +648,7 @@ def test_guard_subnet_delete_returns_empty_when_no_references_exist() -> None:
          patch(f'{ENF_PATH}.find_interfaces_referencing_subnet', return_value=[]):
         errors = _guard_subnet_delete(MagicMock(), MagicMock(), SIBLING_SUBNET_ID)
 
-    assert errors == []
+    assert not errors
 
 
 def test_guard_subnet_delete_returns_only_vlan_error_when_only_vlans_reference_it() -> None:
@@ -673,7 +700,7 @@ def test_enforce_object_invariants_returns_empty_when_type_id_is_not_int() -> No
 
     errors = enforce_object_invariants(MagicMock(), MagicMock(), candidate)
 
-    assert errors == []
+    assert not errors
 
 
 def test_enforce_object_invariants_dispatches_to_supernet_enforcer() -> None:
@@ -766,7 +793,7 @@ def test_enforce_delete_guards_returns_empty_for_invalid_type_id() -> None:
 
     errors = enforce_delete_guards(MagicMock(), MagicMock(), target)
 
-    assert errors == []
+    assert not errors
 
 
 def test_enforce_delete_guards_returns_empty_for_invalid_object_id() -> None:
@@ -775,7 +802,7 @@ def test_enforce_delete_guards_returns_empty_for_invalid_object_id() -> None:
 
     errors = enforce_delete_guards(MagicMock(), MagicMock(), target)
 
-    assert errors == []
+    assert not errors
 
 
 def test_enforce_delete_guards_dispatches_to_supernet_guard_for_supernet_target() -> None:
@@ -813,7 +840,7 @@ def test_enforce_delete_guards_returns_empty_for_vlan_target() -> None:
          patch(f'{ENF_PATH}._guard_subnet_delete') as subnet_mock:
         errors = enforce_delete_guards(MagicMock(), MagicMock(), target)
 
-    assert errors == []
+    assert not errors
     supernet_mock.assert_not_called()
     subnet_mock.assert_not_called()
 
@@ -827,6 +854,6 @@ def test_enforce_delete_guards_returns_empty_for_non_special_type_target() -> No
          patch(f'{ENF_PATH}._guard_subnet_delete') as subnet_mock:
         errors = enforce_delete_guards(MagicMock(), MagicMock(), target)
 
-    assert errors == []
+    assert not errors
     supernet_mock.assert_not_called()
     subnet_mock.assert_not_called()

--- a/tests/unit/framework/ipam/test_interface_validator.py
+++ b/tests/unit/framework/ipam/test_interface_validator.py
@@ -16,39 +16,61 @@
 """
 Unit tests for cmdb.framework.ipam.interface_validator
 
-Covers the pure helpers only — DB-orchestrating functions (_load_subnet_object,
-_check_ip_uniqueness, validate_interface, validate_interface_rows) are deferred to the
-integration tier. Fixture documents reference CmdbObjectKey / CmdbObjectMdsKey /
-CmdbObjectMdsRowKey / CmdbObjectFieldKey / InterfaceField / IpamSection enums for structural
-keys, per the no-magic-values rule
+Covers the pure helpers (membership, collision walking, row matching, batch completeness and
+intra-submission duplicate checks), the DB-touching helpers (_load_subnet_object,
+_check_ip_uniqueness - Mongo query filter shapes pinned via assert_called_once_with) and the
+two orchestrators (validate_interface, validate_interface_rows). For the orchestrators the
+internal helpers are patched at the module path so each test verifies orchestration in
+isolation; every helper has its own dedicated tests in this file. Fixture documents reference
+CmdbObjectKey / CmdbObjectMdsKey / CmdbObjectMdsRowKey / CmdbObjectFieldKey / InterfaceField /
+IpamSection enums for structural keys, per the no-magic-values rule
 """
 from ipaddress import IPv4Address, IPv4Network
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cmdb.utils import ValidationErrorKey
+from cmdb.utils import ValidationErrorKey, build_error
 from cmdb.models.object_model import (
     CmdbObjectKey,
     CmdbObjectFieldKey,
     CmdbObjectMdsKey,
     CmdbObjectMdsRowKey,
 )
+from cmdb.models.special_type_model.special_type_enum import SpecialType
 from cmdb.models.special_type_model.ipam_constants import (
+    SubnetField,
     InterfaceField,
+    IpAddressFamily,
     IpamSection,
     IpamValidationDetailKey,
 )
 from cmdb.framework.ipam.cidr import parse_cidr, parse_ip
 from cmdb.framework.ipam.interface_validator import (
     InterfaceErrorCode,
+    _check_ip_format,
     _check_ip_membership,
+    _check_ip_uniqueness,
+    _check_row_type_against_ip,
+    _check_row_type_against_subnet,
     _collect_collision_errors,
+    _extract_subnet_network,
+    _load_subnet_object,
+    _load_subnets_by_ids,
     _row_matches,
     find_intra_submission_duplicates,
     find_subnet_without_ip,
+    find_type_family_mismatches,
+    validate_interface,
+    validate_interface_rows,
 )
 # -------------------------------------------------------------------------------------------------------------------- #
+
+PATH: str = 'cmdb.framework.ipam.interface_validator'
+SUBNET_TYPE_ID: int = 11
+SUBNET_OBJECT_ID: int = 201
+OWNER_OBJECT_ID: int = 301
 
 
 def _make_interface_row(subnet_id: int | None, ip: str | None) -> dict[str, Any]:
@@ -88,7 +110,7 @@ def test_check_ip_membership_passes_for_regular_host_in_subnet() -> None:
     """An assignable host inside /24 produces no errors"""
     errors = _check_ip_membership(IPv4Address('10.0.0.5'), IPv4Network('10.0.0.0/24'))
 
-    assert errors == []
+    assert not errors
 
 
 def test_check_ip_membership_short_circuits_when_ip_outside_subnet() -> None:
@@ -117,28 +139,28 @@ def test_check_ip_membership_allows_both_endpoints_of_slash31(point_to_point_ip:
     """/31 endpoints are assignable under the point-to-point policy (no IP_RESERVED)"""
     errors = _check_ip_membership(IPv4Address(point_to_point_ip), IPv4Network('10.0.0.0/31'))
 
-    assert errors == []
+    assert not errors
 
 
 def test_check_ip_membership_allows_single_host_of_slash32() -> None:
     """/32 host route is assignable under the host-route policy (no IP_RESERVED)"""
     errors = _check_ip_membership(IPv4Address('10.0.0.5'), IPv4Network('10.0.0.5/32'))
 
-    assert errors == []
+    assert not errors
 
 
 def test_check_ip_membership_passes_for_ipv6_host_in_ipv6_subnet() -> None:
     """An IPv6 host inside an IPv6 subnet produces no errors"""
     errors = _check_ip_membership(parse_ip('2001:db8::5'), parse_cidr('2001:db8::/64'))
 
-    assert errors == []
+    assert not errors
 
 
 def test_check_ip_membership_allows_ipv6_network_address_no_reservation() -> None:
     """IPv6 reserves no network/broadcast address, so the all-zeros host is assignable"""
     errors = _check_ip_membership(parse_ip('2001:db8::'), parse_cidr('2001:db8::/64'))
 
-    assert errors == []
+    assert not errors
 
 
 def test_check_ip_membership_rejects_ipv4_ip_in_ipv6_subnet() -> None:
@@ -238,7 +260,7 @@ def test_collect_collision_errors_skips_excluded_self_row() -> None:
         exclude_row_index=0,
     )
 
-    assert errors == []
+    assert not errors
 
 
 def test_collect_collision_errors_reports_other_row_on_same_object() -> None:
@@ -283,7 +305,7 @@ def test_collect_collision_errors_ignores_non_interface_sections() -> None:
         exclude_row_index=None,
     )
 
-    assert errors == []
+    assert not errors
 
 
 def test_collect_collision_errors_returns_empty_for_no_candidates() -> None:
@@ -296,7 +318,7 @@ def test_collect_collision_errors_returns_empty_for_no_candidates() -> None:
         exclude_row_index=None,
     )
 
-    assert errors == []
+    assert not errors
 
 
 def test_collect_collision_errors_reports_one_error_per_matching_row_across_objects() -> None:
@@ -325,19 +347,19 @@ def test_collect_collision_errors_reports_one_error_per_matching_row_across_obje
 def test_find_intra_submission_duplicates_returns_empty_for_unique_rows() -> None:
     """Rows with distinct (subnet, IP) pairs produce no errors"""
     rows = [
-        (0, 1, '10.0.0.1'),
-        (1, 1, '10.0.0.2'),
-        (2, 2, '10.0.0.1'),
+        (0, 1, '10.0.0.1', None),
+        (1, 1, '10.0.0.2', None),
+        (2, 2, '10.0.0.1', None),
     ]
 
-    assert find_intra_submission_duplicates(rows) == []
+    assert not find_intra_submission_duplicates(rows)
 
 
 def test_find_intra_submission_duplicates_flags_second_occurrence() -> None:
     """The first occurrence wins; the second occurrence is reported with both row indices"""
     rows = [
-        (0, 1, '10.0.0.1'),
-        (1, 1, '10.0.0.1'),
+        (0, 1, '10.0.0.1', None),
+        (1, 1, '10.0.0.1', None),
     ]
 
     errors = find_intra_submission_duplicates(rows)
@@ -352,9 +374,9 @@ def test_find_intra_submission_duplicates_flags_second_occurrence() -> None:
 def test_find_intra_submission_duplicates_flags_each_subsequent_occurrence() -> None:
     """Three identical rows produce two errors (second and third both against the first)"""
     rows = [
-        (0, 1, '10.0.0.1'),
-        (1, 1, '10.0.0.1'),
-        (2, 1, '10.0.0.1'),
+        (0, 1, '10.0.0.1', None),
+        (1, 1, '10.0.0.1', None),
+        (2, 1, '10.0.0.1', None),
     ]
 
     errors = find_intra_submission_duplicates(rows)
@@ -368,10 +390,10 @@ def test_find_intra_submission_duplicates_flags_each_subsequent_occurrence() -> 
 def test_find_intra_submission_duplicates_skips_incomplete_rows() -> None:
     """Rows missing subnet_ref or ip are not considered for duplicate detection"""
     rows = [
-        (0, 1, '10.0.0.1'),
-        (1, None, '10.0.0.1'),
-        (2, 1, None),
-        (3, 1, '10.0.0.1'),
+        (0, 1, '10.0.0.1', None),
+        (1, None, '10.0.0.1', None),
+        (2, 1, None, None),
+        (3, 1, '10.0.0.1', None),
     ]
 
     errors = find_intra_submission_duplicates(rows)
@@ -385,16 +407,16 @@ def test_find_intra_submission_duplicates_skips_incomplete_rows() -> None:
 def test_find_intra_submission_duplicates_treats_different_subnets_as_distinct() -> None:
     """Same IP under different subnets is allowed (only the (subnet, IP) pair is unique)"""
     rows = [
-        (0, 1, '10.0.0.1'),
-        (1, 2, '10.0.0.1'),
+        (0, 1, '10.0.0.1', None),
+        (1, 2, '10.0.0.1', None),
     ]
 
-    assert find_intra_submission_duplicates(rows) == []
+    assert not find_intra_submission_duplicates(rows)
 
 
 def test_find_intra_submission_duplicates_returns_empty_for_empty_input() -> None:
     """No rows submitted means no errors"""
-    assert find_intra_submission_duplicates([]) == []
+    assert not find_intra_submission_duplicates([])
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -402,33 +424,33 @@ def test_find_intra_submission_duplicates_returns_empty_for_empty_input() -> Non
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_find_subnet_without_ip_returns_empty_for_empty_input() -> None:
     """No rows submitted means no errors"""
-    assert find_subnet_without_ip([]) == []
+    assert not find_subnet_without_ip([])
 
 
 def test_find_subnet_without_ip_accepts_complete_row() -> None:
     """A row with both subnet_ref and ip set produces no error"""
-    rows = [(0, 1, '10.0.0.1')]
+    rows = [(0, 1, '10.0.0.1', None)]
 
-    assert find_subnet_without_ip(rows) == []
+    assert not find_subnet_without_ip(rows)
 
 
 def test_find_subnet_without_ip_accepts_empty_placeholder_row() -> None:
     """A row with neither subnet_ref nor ip set is treated as an empty placeholder and accepted"""
-    rows = [(0, None, None)]
+    rows = [(0, None, None, None)]
 
-    assert find_subnet_without_ip(rows) == []
+    assert not find_subnet_without_ip(rows)
 
 
 def test_find_subnet_without_ip_accepts_ip_only_row_per_literal_scope() -> None:
     """A row with ip set but no subnet is allowed (inverse case is not in scope)"""
-    rows = [(0, None, '10.0.0.1')]
+    rows = [(0, None, '10.0.0.1', None)]
 
-    assert find_subnet_without_ip(rows) == []
+    assert not find_subnet_without_ip(rows)
 
 
 def test_find_subnet_without_ip_flags_row_with_subnet_but_no_ip() -> None:
     """A row with subnet_ref set and ip None produces one SUBNET_WITHOUT_IP error"""
-    rows = [(3, 42, None)]
+    rows = [(3, 42, None, None)]
 
     errors = find_subnet_without_ip(rows)
 
@@ -442,9 +464,9 @@ def test_find_subnet_without_ip_flags_row_with_subnet_but_no_ip() -> None:
 def test_find_subnet_without_ip_flags_multiple_offending_rows_in_order() -> None:
     """Each offending row produces its own error; emission order matches input order"""
     rows = [
-        (0, 1, None),
-        (1, 1, '10.0.0.1'),
-        (2, 2, None),
+        (0, 1, None, None),
+        (1, 1, '10.0.0.1', None),
+        (2, 2, None, None),
     ]
 
     errors = find_subnet_without_ip(rows)
@@ -457,10 +479,10 @@ def test_find_subnet_without_ip_flags_multiple_offending_rows_in_order() -> None
 def test_find_subnet_without_ip_flags_only_offending_rows_in_mixed_batch() -> None:
     """A mixed batch produces errors only for the subnet-without-ip rows, leaving valid + empty rows alone"""
     rows = [
-        (0, 1, '10.0.0.1'),  # valid
-        (1, None, None),     # empty placeholder
-        (2, 2, None),        # offending
-        (3, None, '10.0.0.2'),  # ip-only, literal-scope passes
+        (0, 1, '10.0.0.1', None),  # valid
+        (1, None, None, None),     # empty placeholder
+        (2, 2, None, None),        # offending
+        (3, None, '10.0.0.2', None),  # ip-only, literal-scope passes
     ]
 
     errors = find_subnet_without_ip(rows)
@@ -471,7 +493,7 @@ def test_find_subnet_without_ip_flags_only_offending_rows_in_mixed_batch() -> No
 
 def test_find_subnet_without_ip_error_envelope_carries_code_message_and_details() -> None:
     """The structured error envelope exposes code + a non-empty message + the documented detail keys"""
-    rows = [(7, 99, None)]
+    rows = [(7, 99, None, None)]
 
     error = find_subnet_without_ip(rows)[0]
 
@@ -482,3 +504,543 @@ def test_find_subnet_without_ip_error_envelope_carries_code_message_and_details(
         IpamValidationDetailKey.ROW_INDEX,
         IpamValidationDetailKey.SUBNET_OBJECT_ID,
     }
+
+
+def _make_subnet_doc(public_id: int, network_range: Any = None) -> dict[str, Any]:
+    """Builds a SUBNET CmdbObject doc with an optional network-range field."""
+    fields: list[dict[str, Any]] = []
+
+    if network_range is not None:
+        fields.append(
+            {CmdbObjectFieldKey.NAME: SubnetField.NETWORK_RANGE, CmdbObjectFieldKey.VALUE: network_range},
+        )
+
+    return {
+        CmdbObjectKey.PUBLIC_ID: public_id,
+        CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID,
+        CmdbObjectKey.FIELDS: fields,
+    }
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               _load_subnet_object                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_load_subnet_object_errors_when_subnet_type_undefined() -> None:
+    """Without a SUBNET CmdbType the loader emits SUBNET_TYPE_MISSING and skips the object query"""
+    objects_manager = MagicMock()
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=None):
+        subnet_obj, errors = _load_subnet_object(objects_manager, MagicMock(), SUBNET_OBJECT_ID)
+
+    assert subnet_obj is None
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.SUBNET_TYPE_MISSING
+    objects_manager.find_objects.assert_not_called()
+
+
+def test_load_subnet_object_pins_the_id_and_type_criteria() -> None:
+    """The loader queries exactly {public_id, type_id} with as_dict=True"""
+    objects_manager = MagicMock()
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='10.0.0.0/24')
+    objects_manager.find_objects.return_value = [doc]
+    types_manager = MagicMock()
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID) as mock_resolve:
+        subnet_obj, errors = _load_subnet_object(objects_manager, types_manager, SUBNET_OBJECT_ID)
+
+    mock_resolve.assert_called_once_with(types_manager, SpecialType.SUBNET)
+    objects_manager.find_objects.assert_called_once_with(
+        {CmdbObjectKey.PUBLIC_ID: SUBNET_OBJECT_ID, CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID},
+        as_dict=True,
+    )
+    assert subnet_obj is doc
+    assert not errors
+
+
+def test_load_subnet_object_errors_when_no_match() -> None:
+    """An id that matches no SUBNET emits SUBNET_NOT_FOUND with the id in the details"""
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = []
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        subnet_obj, errors = _load_subnet_object(objects_manager, MagicMock(), SUBNET_OBJECT_ID)
+
+    assert subnet_obj is None
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.SUBNET_NOT_FOUND
+    assert errors[0][ValidationErrorKey.DETAILS][IpamValidationDetailKey.SUBNET_OBJECT_ID] == SUBNET_OBJECT_ID
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              _extract_subnet_network                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_extract_subnet_network_parses_a_valid_range() -> None:
+    """A canonical CIDR parses into the network with no errors"""
+    network, errors = _extract_subnet_network(_make_subnet_doc(SUBNET_OBJECT_ID, network_range='10.0.0.0/24'))
+
+    assert network == IPv4Network('10.0.0.0/24')
+    assert not errors
+
+
+@pytest.mark.parametrize('bad_range', [None, 12345, 'not-a-cidr', '10.0.0.5/24'])
+def test_extract_subnet_network_errors_on_missing_or_unparsable_range(bad_range: Any) -> None:
+    """A missing, non-string or non-canonical range emits SUBNET_BROKEN_STATE with the stored value"""
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID, network_range=bad_range)
+
+    network, errors = _extract_subnet_network(doc)
+
+    assert network is None
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.SUBNET_BROKEN_STATE
+    details = errors[0][ValidationErrorKey.DETAILS]
+    assert details[IpamValidationDetailKey.SUBNET_OBJECT_ID] == SUBNET_OBJECT_ID
+    assert details[IpamValidationDetailKey.STORED_VALUE] == bad_range
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                 _check_ip_format                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+@pytest.mark.parametrize('valid_ip', ['10.0.0.5', '2001:db8::5'])
+def test_check_ip_format_parses_both_families(valid_ip: str) -> None:
+    """A valid IPv4 / IPv6 address parses with no errors"""
+    parsed, errors = _check_ip_format(valid_ip)
+
+    assert parsed == parse_ip(valid_ip)
+    assert not errors
+
+
+def test_check_ip_format_errors_on_invalid_address() -> None:
+    """An unparsable address emits IP_INVALID carrying the candidate string"""
+    parsed, errors = _check_ip_format('not-an-ip')
+
+    assert parsed is None
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.IP_INVALID
+    assert errors[0][ValidationErrorKey.DETAILS][IpamValidationDetailKey.IP_ADDRESS] == 'not-an-ip'
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               _check_ip_uniqueness                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_check_ip_uniqueness_pins_the_collision_query() -> None:
+    """The Mongo filter requires one interface row carrying both the subnet ref and the IP"""
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = []
+
+    errors = _check_ip_uniqueness(objects_manager, SUBNET_OBJECT_ID, '10.0.0.5', None, None)
+
+    objects_manager.find_objects.assert_called_once_with(
+        {
+            CmdbObjectKey.MULTI_DATA_SECTIONS: {
+                '$elemMatch': {
+                    CmdbObjectMdsKey.SECTION_ID: IpamSection.INTERFACE,
+                    CmdbObjectMdsKey.VALUES: {
+                        '$elemMatch': {
+                            CmdbObjectMdsRowKey.DATA: {
+                                '$all': [
+                                    {'$elemMatch': {
+                                        CmdbObjectFieldKey.NAME: InterfaceField.SUBNET,
+                                        CmdbObjectFieldKey.VALUE: SUBNET_OBJECT_ID,
+                                    }},
+                                    {'$elemMatch': {
+                                        CmdbObjectFieldKey.NAME: InterfaceField.IP,
+                                        CmdbObjectFieldKey.VALUE: '10.0.0.5',
+                                    }},
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        as_dict=True,
+    )
+    assert not errors
+
+
+def test_check_ip_uniqueness_reports_collisions_from_the_candidates() -> None:
+    """A candidate row matching the (subnet, IP) pair yields one IP_DUPLICATE error"""
+    objects_manager = MagicMock()
+    carrier = _make_object(OWNER_OBJECT_ID, [_make_interface_row(SUBNET_OBJECT_ID, '10.0.0.5')])
+    objects_manager.find_objects.return_value = [carrier]
+
+    errors = _check_ip_uniqueness(objects_manager, SUBNET_OBJECT_ID, '10.0.0.5', None, None)
+
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.IP_DUPLICATE
+    assert errors[0][ValidationErrorKey.DETAILS][IpamValidationDetailKey.OBJECT_ID] == OWNER_OBJECT_ID
+
+
+def test_check_ip_uniqueness_honours_the_self_exclusion_pair() -> None:
+    """The candidate's own pre-edit row (object id + row index) is not flagged against itself"""
+    objects_manager = MagicMock()
+    carrier = _make_object(OWNER_OBJECT_ID, [_make_interface_row(SUBNET_OBJECT_ID, '10.0.0.5')])
+    objects_manager.find_objects.return_value = [carrier]
+
+    errors = _check_ip_uniqueness(
+        objects_manager, SUBNET_OBJECT_ID, '10.0.0.5',
+        exclude_object_id=OWNER_OBJECT_ID, exclude_row_index=0,
+    )
+
+    assert not errors
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                validate_interface                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_validate_interface_short_circuits_when_subnet_load_fails() -> None:
+    """A failed subnet load returns the load errors without running any further check"""
+    load_error = build_error(InterfaceErrorCode.SUBNET_NOT_FOUND, 'gone')
+
+    with patch(f'{PATH}._load_subnet_object', return_value=(None, [load_error])), \
+         patch(f'{PATH}._extract_subnet_network') as mock_extract, \
+         patch(f'{PATH}._check_ip_format') as mock_format, \
+         patch(f'{PATH}._check_ip_uniqueness') as mock_unique:
+        errors = validate_interface(MagicMock(), MagicMock(), SUBNET_OBJECT_ID, '10.0.0.5')
+
+    assert errors == [load_error]
+    mock_extract.assert_not_called()
+    mock_format.assert_not_called()
+    mock_unique.assert_not_called()
+
+
+def test_validate_interface_returns_empty_for_a_valid_row() -> None:
+    """With every check clean the orchestrator returns no errors and forwards the exclude pair"""
+    objects_manager = MagicMock()
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='10.0.0.0/24')
+    network = parse_cidr('10.0.0.0/24')
+    ip = parse_ip('10.0.0.5')
+
+    with patch(f'{PATH}._load_subnet_object', return_value=(subnet_doc, [])), \
+         patch(f'{PATH}._extract_subnet_network', return_value=(network, [])), \
+         patch(f'{PATH}._check_ip_format', return_value=(ip, [])), \
+         patch(f'{PATH}._check_ip_membership', return_value=[]) as mock_membership, \
+         patch(f'{PATH}._check_ip_uniqueness', return_value=[]) as mock_unique:
+        errors = validate_interface(
+            objects_manager, MagicMock(), SUBNET_OBJECT_ID, '10.0.0.5',
+            exclude_object_id=OWNER_OBJECT_ID, exclude_row_index=2,
+        )
+
+    assert not errors
+    mock_membership.assert_called_once_with(ip, network)
+    mock_unique.assert_called_once_with(
+        objects_manager, SUBNET_OBJECT_ID, '10.0.0.5', OWNER_OBJECT_ID, 2,
+    )
+
+
+def test_validate_interface_skips_membership_when_range_broken_but_still_checks_uniqueness() -> None:
+    """A broken subnet range plus a valid IP: membership is skipped, uniqueness still runs"""
+    range_error = build_error(InterfaceErrorCode.SUBNET_BROKEN_STATE, 'broken')
+    ip = parse_ip('10.0.0.5')
+
+    with patch(f'{PATH}._load_subnet_object', return_value=(_make_subnet_doc(SUBNET_OBJECT_ID), [])), \
+         patch(f'{PATH}._extract_subnet_network', return_value=(None, [range_error])), \
+         patch(f'{PATH}._check_ip_format', return_value=(ip, [])), \
+         patch(f'{PATH}._check_ip_membership') as mock_membership, \
+         patch(f'{PATH}._check_ip_uniqueness', return_value=[]) as mock_unique:
+        errors = validate_interface(MagicMock(), MagicMock(), SUBNET_OBJECT_ID, '10.0.0.5')
+
+    assert errors == [range_error]
+    mock_membership.assert_not_called()
+    mock_unique.assert_called_once()
+
+
+def test_validate_interface_skips_membership_and_uniqueness_when_ip_invalid() -> None:
+    """An unparsable IP collects the format error and skips both IP-dependent checks"""
+    ip_error = build_error(InterfaceErrorCode.IP_INVALID, 'bad ip')
+    network = parse_cidr('10.0.0.0/24')
+
+    with patch(f'{PATH}._load_subnet_object', return_value=(_make_subnet_doc(SUBNET_OBJECT_ID), [])), \
+         patch(f'{PATH}._extract_subnet_network', return_value=(network, [])), \
+         patch(f'{PATH}._check_ip_format', return_value=(None, [ip_error])), \
+         patch(f'{PATH}._check_ip_membership') as mock_membership, \
+         patch(f'{PATH}._check_ip_uniqueness') as mock_unique:
+        errors = validate_interface(MagicMock(), MagicMock(), SUBNET_OBJECT_ID, 'not-an-ip')
+
+    assert errors == [ip_error]
+    mock_membership.assert_not_called()
+    mock_unique.assert_not_called()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              validate_interface_rows                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_validate_interface_rows_returns_empty_for_an_empty_batch() -> None:
+    """An empty row list short-circuits without invoking any check"""
+    with patch(f'{PATH}.find_subnet_without_ip') as mock_completeness, \
+         patch(f'{PATH}.find_intra_submission_duplicates') as mock_duplicates, \
+         patch(f'{PATH}.find_type_family_mismatches') as mock_type_check, \
+         patch(f'{PATH}.validate_interface') as mock_validate:
+        errors = validate_interface_rows(MagicMock(), MagicMock(), [])
+
+    assert not errors
+    mock_completeness.assert_not_called()
+    mock_duplicates.assert_not_called()
+    mock_type_check.assert_not_called()
+    mock_validate.assert_not_called()
+
+
+def test_validate_interface_rows_concatenates_batch_and_per_row_errors_in_order() -> None:
+    """Completeness errors come first, then duplicates, then type mismatches, then per-row results"""
+    completeness_error = build_error(InterfaceErrorCode.SUBNET_WITHOUT_IP, 'no ip')
+    duplicate_error = build_error(InterfaceErrorCode.IP_DUPLICATE, 'twice')
+    type_error = build_error(InterfaceErrorCode.TYPE_FAMILY_MISMATCH, 'wrong family')
+    row_error = build_error(InterfaceErrorCode.IP_NOT_IN_SUBNET, 'outside')
+    rows: list[tuple[int, int | None, str | None, str | None]] = [(0, SUBNET_OBJECT_ID, '10.0.0.5', None)]
+
+    with patch(f'{PATH}.find_subnet_without_ip', return_value=[completeness_error]), \
+         patch(f'{PATH}.find_intra_submission_duplicates', return_value=[duplicate_error]), \
+         patch(f'{PATH}.find_type_family_mismatches', return_value=[type_error]) as mock_type_check, \
+         patch(f'{PATH}.validate_interface', return_value=[row_error]):
+        errors = validate_interface_rows(MagicMock(), MagicMock(), rows)
+
+    assert errors == [completeness_error, duplicate_error, type_error, row_error]
+    assert mock_type_check.call_args.args[2] is rows
+
+
+def test_validate_interface_rows_skips_incomplete_rows_in_the_per_row_pass() -> None:
+    """Rows missing the subnet ref or the IP never reach validate_interface"""
+    rows: list[tuple[int, int | None, str | None, str | None]] = [
+        (0, None, '10.0.0.5', None),
+        (1, SUBNET_OBJECT_ID, None, None),
+        (2, None, None, None),
+        (3, SUBNET_OBJECT_ID, '10.0.0.7', None),
+    ]
+
+    with patch(f'{PATH}.find_subnet_without_ip', return_value=[]), \
+         patch(f'{PATH}.find_intra_submission_duplicates', return_value=[]), \
+         patch(f'{PATH}.validate_interface', return_value=[]) as mock_validate:
+        validate_interface_rows(MagicMock(), MagicMock(), rows)
+
+    assert mock_validate.call_count == 1
+    assert mock_validate.call_args.kwargs['subnet_object_id'] == SUBNET_OBJECT_ID
+    assert mock_validate.call_args.kwargs['ip_address'] == '10.0.0.7'
+
+
+def test_validate_interface_rows_forwards_exclusion_and_injects_row_index() -> None:
+    """Each per-row call gets (exclude_object_id, row_index) and its errors gain details.row_index"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    error_without_details = {
+        ValidationErrorKey.CODE: InterfaceErrorCode.IP_DUPLICATE,
+        ValidationErrorKey.MESSAGE: 'collision',
+    }
+    rows: list[tuple[int, int | None, str | None, str | None]] = [(5, SUBNET_OBJECT_ID, '10.0.0.5', None)]
+
+    with patch(f'{PATH}.find_subnet_without_ip', return_value=[]), \
+         patch(f'{PATH}.find_intra_submission_duplicates', return_value=[]), \
+         patch(f'{PATH}.validate_interface', return_value=[error_without_details]) as mock_validate:
+        errors = validate_interface_rows(
+            objects_manager, types_manager, rows, exclude_object_id=OWNER_OBJECT_ID,
+        )
+
+    mock_validate.assert_called_once_with(
+        objects_manager,
+        types_manager,
+        subnet_object_id=SUBNET_OBJECT_ID,
+        ip_address='10.0.0.5',
+        exclude_object_id=OWNER_OBJECT_ID,
+        exclude_row_index=5,
+    )
+    assert errors[0][ValidationErrorKey.DETAILS][IpamValidationDetailKey.ROW_INDEX] == 5
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               _load_subnets_by_ids                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_load_subnets_by_ids_pins_the_batch_criteria_and_keys_by_public_id() -> None:
+    """One $in query loads every referenced subnet; the result is keyed by public_id"""
+    objects_manager = MagicMock()
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='10.0.0.0/24')
+    objects_manager.find_objects.return_value = [doc]
+    types_manager = MagicMock()
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        result = _load_subnets_by_ids(objects_manager, types_manager, [SUBNET_OBJECT_ID])
+
+    objects_manager.find_objects.assert_called_once_with(
+        {CmdbObjectKey.PUBLIC_ID: {'$in': [SUBNET_OBJECT_ID]}, CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID},
+        as_dict=True,
+    )
+    assert result == {SUBNET_OBJECT_ID: doc}
+
+
+def test_load_subnets_by_ids_returns_empty_without_ids_or_subnet_type() -> None:
+    """An empty id list and a missing SUBNET CmdbType both yield {} without querying"""
+    objects_manager = MagicMock()
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        assert _load_subnets_by_ids(objects_manager, MagicMock(), []) == {}
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=None):
+        assert _load_subnets_by_ids(objects_manager, MagicMock(), [SUBNET_OBJECT_ID]) == {}
+
+    objects_manager.find_objects.assert_not_called()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            _check_row_type_against_ip                                                #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_check_row_type_against_ip_passes_on_matching_family() -> None:
+    """A matching token / IP family pair produces no errors (both families)"""
+    assert not _check_row_type_against_ip(0, IpAddressFamily.IPV4, '10.0.0.5')
+    assert not _check_row_type_against_ip(0, IpAddressFamily.IPV6, '2001:db8::5')
+
+
+def test_check_row_type_against_ip_flags_contradicting_family() -> None:
+    """An ipv4 token on an IPv6 address emits TYPE_FAMILY_MISMATCH with full details"""
+    errors = _check_row_type_against_ip(3, IpAddressFamily.IPV4, '2001:db8::5')
+
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.TYPE_FAMILY_MISMATCH
+    details = errors[0][ValidationErrorKey.DETAILS]
+    assert details[IpamValidationDetailKey.ROW_INDEX] == 3
+    assert details[IpamValidationDetailKey.INTERFACE_TYPE] == IpAddressFamily.IPV4
+    assert details[IpamValidationDetailKey.IP_ADDRESS] == '2001:db8::5'
+    assert details[IpamValidationDetailKey.IP_FAMILY] == IpAddressFamily.IPV6
+
+
+def test_check_row_type_against_ip_treats_unrecognised_token_as_mismatch() -> None:
+    """A token outside IpAddressFamily can never match the parsed family"""
+    errors = _check_row_type_against_ip(0, 'ipv5', '10.0.0.5')
+
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.TYPE_FAMILY_MISMATCH
+
+
+def test_check_row_type_against_ip_skips_unparsable_ip() -> None:
+    """An unparsable IP is reported as IP_INVALID elsewhere, not as a family mismatch"""
+    assert not _check_row_type_against_ip(0, IpAddressFamily.IPV4, 'not-an-ip')
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          _check_row_type_against_subnet                                              #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_check_row_type_against_subnet_passes_on_matching_family() -> None:
+    """A matching token / subnet-CIDR family pair produces no errors"""
+    subnet = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='10.0.0.0/24')
+
+    assert not _check_row_type_against_subnet(0, IpAddressFamily.IPV4, subnet)
+
+
+def test_check_row_type_against_subnet_flags_contradicting_family() -> None:
+    """An ipv4 token on an IPv6 subnet emits TYPE_FAMILY_MISMATCH with full details"""
+    subnet = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='2001:db8::/64')
+
+    errors = _check_row_type_against_subnet(2, IpAddressFamily.IPV4, subnet)
+
+    assert len(errors) == 1
+    assert errors[0][ValidationErrorKey.CODE] == InterfaceErrorCode.TYPE_FAMILY_MISMATCH
+    details = errors[0][ValidationErrorKey.DETAILS]
+    assert details[IpamValidationDetailKey.ROW_INDEX] == 2
+    assert details[IpamValidationDetailKey.INTERFACE_TYPE] == IpAddressFamily.IPV4
+    assert details[IpamValidationDetailKey.SUBNET_OBJECT_ID] == SUBNET_OBJECT_ID
+    assert details[IpamValidationDetailKey.SUBNET_RANGE] == '2001:db8::/64'
+    assert details[IpamValidationDetailKey.SUBNET_FAMILY] == IpAddressFamily.IPV6
+
+
+def test_check_row_type_against_subnet_skips_unparsable_range() -> None:
+    """A broken subnet range is reported as SUBNET_BROKEN_STATE elsewhere, not here"""
+    subnet = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='not-a-cidr')
+
+    assert not _check_row_type_against_subnet(0, IpAddressFamily.IPV4, subnet)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            find_type_family_mismatches                                               #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_find_type_family_mismatches_skips_rows_without_a_token_entirely() -> None:
+    """Untyped rows never trigger the subnet batch load - legacy rows stay silent"""
+    objects_manager = MagicMock()
+    rows: list[tuple[int, int | None, str | None, str | None]] = [
+        (0, SUBNET_OBJECT_ID, '2001:db8::5', None),
+    ]
+
+    errors = find_type_family_mismatches(objects_manager, MagicMock(), rows)
+
+    assert not errors
+    objects_manager.find_objects.assert_not_called()
+
+
+def test_find_type_family_mismatches_reports_ip_and_subnet_contradictions_per_row() -> None:
+    """A typed row contradicting both its IP and its subnet yields two mismatch errors"""
+    objects_manager = MagicMock()
+    v6_subnet = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='2001:db8::/64')
+    objects_manager.find_objects.return_value = [v6_subnet]
+    rows: list[tuple[int, int | None, str | None, str | None]] = [
+        (0, SUBNET_OBJECT_ID, '2001:db8::5', IpAddressFamily.IPV4),
+    ]
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        errors = find_type_family_mismatches(objects_manager, MagicMock(), rows)
+
+    assert len(errors) == 2
+    assert all(e[ValidationErrorKey.CODE] == InterfaceErrorCode.TYPE_FAMILY_MISMATCH for e in errors)
+    assert errors[0][ValidationErrorKey.DETAILS][IpamValidationDetailKey.IP_FAMILY] == IpAddressFamily.IPV6
+    assert errors[1][ValidationErrorKey.DETAILS][IpamValidationDetailKey.SUBNET_FAMILY] == IpAddressFamily.IPV6
+
+
+def test_find_type_family_mismatches_passes_consistent_typed_rows() -> None:
+    """A typed row whose IP and subnet agree with the token produces no errors"""
+    objects_manager = MagicMock()
+    v4_subnet = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='10.0.0.0/24')
+    objects_manager.find_objects.return_value = [v4_subnet]
+    rows: list[tuple[int, int | None, str | None, str | None]] = [
+        (0, SUBNET_OBJECT_ID, '10.0.0.5', IpAddressFamily.IPV4),
+    ]
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        errors = find_type_family_mismatches(objects_manager, MagicMock(), rows)
+
+    assert not errors
+
+
+def test_find_type_family_mismatches_checks_partial_rows_against_present_data_only() -> None:
+    """Type+IP without subnet and type+subnet without IP are each checked against what exists"""
+    objects_manager = MagicMock()
+    v4_subnet = _make_subnet_doc(SUBNET_OBJECT_ID, network_range='10.0.0.0/24')
+    objects_manager.find_objects.return_value = [v4_subnet]
+    rows: list[tuple[int, int | None, str | None, str | None]] = [
+        (0, None, '10.0.0.5', IpAddressFamily.IPV6),
+        (1, SUBNET_OBJECT_ID, None, IpAddressFamily.IPV6),
+    ]
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        errors = find_type_family_mismatches(objects_manager, MagicMock(), rows)
+
+    assert len(errors) == 2
+    assert errors[0][ValidationErrorKey.DETAILS][IpamValidationDetailKey.ROW_INDEX] == 0
+    assert IpamValidationDetailKey.IP_ADDRESS in errors[0][ValidationErrorKey.DETAILS]
+    assert errors[1][ValidationErrorKey.DETAILS][IpamValidationDetailKey.ROW_INDEX] == 1
+    assert IpamValidationDetailKey.SUBNET_OBJECT_ID in errors[1][ValidationErrorKey.DETAILS]
+
+
+def test_find_type_family_mismatches_skips_unknown_subnet_refs() -> None:
+    """A typed row referencing a subnet id that resolves to nothing is skipped silently"""
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = []
+    rows: list[tuple[int, int | None, str | None, str | None]] = [
+        (0, SUBNET_OBJECT_ID, None, IpAddressFamily.IPV4),
+    ]
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        errors = find_type_family_mismatches(objects_manager, MagicMock(), rows)
+
+    assert not errors
+
+
+def test_find_type_family_mismatches_loads_referenced_subnets_in_one_sorted_batch() -> None:
+    """All typed rows' subnet refs land deduplicated and sorted in a single $in query"""
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = []
+    rows: list[tuple[int, int | None, str | None, str | None]] = [
+        (0, SUBNET_OBJECT_ID + 1, None, IpAddressFamily.IPV4),
+        (1, SUBNET_OBJECT_ID, None, IpAddressFamily.IPV4),
+        (2, SUBNET_OBJECT_ID, None, IpAddressFamily.IPV6),
+    ]
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID):
+        find_type_family_mismatches(objects_manager, MagicMock(), rows)
+
+    criteria = objects_manager.find_objects.call_args.args[0]
+    assert criteria[CmdbObjectKey.PUBLIC_ID] == {'$in': [SUBNET_OBJECT_ID, SUBNET_OBJECT_ID + 1]}

--- a/tests/unit/framework/ipam/test_subnet_export.py
+++ b/tests/unit/framework/ipam/test_subnet_export.py
@@ -26,11 +26,19 @@ from unittest.mock import MagicMock, patch
 
 from openpyxl import load_workbook
 
-from cmdb.models.special_type_model.ipam_constants import IpamOverviewKey, IpamExport, IpAddressFamily
+from cmdb.models.special_type_model.ipam_constants import (
+    IpamOverviewKey,
+    IpamExport,
+    IpamSubnetIpsExport,
+    IpamRowStatus,
+    IpAddressFamily,
+)
 from cmdb.framework.ipam.subnet_export import (
     _format_ip_range,
     _subnet_export_row,
+    _subnet_ip_export_row,
     build_supernet_subnets_xlsx,
+    build_subnet_ips_xlsx,
 )
 # -------------------------------------------------------------------------------------------------------------------- #
 
@@ -130,3 +138,64 @@ def test_build_supernet_subnets_xlsx_emits_header_only_when_no_subnets() -> None
     rows: list[tuple[Any, ...]] = list(load_workbook(BytesIO(content)).active.iter_rows(values_only=True))
 
     assert rows == [tuple(IpamExport.HEADERS + [IpamExport.USAGE_HEADER])]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            _subnet_ip_export_row                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+IP_ROW_ASSIGNED: dict[str, Any] = {
+    IpamOverviewKey.IP: '10.0.0.5',
+    IpamOverviewKey.STATUS: IpamRowStatus.ASSIGNED,
+    IpamOverviewKey.TYPE_INFO: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: '#fff'},
+    IpamOverviewKey.ASSIGNED_TO: {IpamOverviewKey.SUMMARY_LINE: 'Server: web01'},
+    IpamOverviewKey.MAC_ADDRESS: 'aa:bb:cc:dd:ee:ff',
+}
+IP_ROW_FREE: dict[str, Any] = {
+    IpamOverviewKey.IP: '10.0.0.6',
+    IpamOverviewKey.STATUS: IpamRowStatus.FREE,
+    IpamOverviewKey.TYPE_INFO: None,
+    IpamOverviewKey.ASSIGNED_TO: None,
+    IpamOverviewKey.MAC_ADDRESS: None,
+}
+
+
+def test_subnet_ip_export_row_maps_assigned_row_to_human_readable_cells() -> None:
+    """An assigned row carries the type label, status, owner summary line and MAC"""
+    assert _subnet_ip_export_row(IP_ROW_ASSIGNED) == [
+        '10.0.0.5', 'Server', IpamRowStatus.ASSIGNED, 'Server: web01', 'aa:bb:cc:dd:ee:ff',
+    ]
+
+
+def test_subnet_ip_export_row_blanks_type_owner_and_mac_for_free_row() -> None:
+    """A free row leaves the type, assigned-to and MAC cells blank (not None)"""
+    assert _subnet_ip_export_row(IP_ROW_FREE) == ['10.0.0.6', '', IpamRowStatus.FREE, '', '']
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            build_subnet_ips_xlsx                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+def test_build_subnet_ips_xlsx_writes_headers_and_rows() -> None:
+    """The workbook carries the IP-export sheet title, header row and one data row per IP"""
+    with patch(f'{MODULE}.build_subnet_ip_export_rows', return_value=[IP_ROW_ASSIGNED, IP_ROW_FREE]):
+        content: bytes = build_subnet_ips_xlsx(MagicMock(), MagicMock(), 7)
+
+    sheet = load_workbook(BytesIO(content)).active
+    assert sheet.title == IpamSubnetIpsExport.SHEET_TITLE
+
+    rows: list[tuple[Any, ...]] = list(sheet.iter_rows(values_only=True))
+    assert rows[0] == tuple(IpamSubnetIpsExport.HEADERS)
+    assert rows[1] == ('10.0.0.5', 'Server', IpamRowStatus.ASSIGNED, 'Server: web01', 'aa:bb:cc:dd:ee:ff')
+    # the free row's blank cells round-trip back through openpyxl as empty (None) cells
+    assert rows[2] == ('10.0.0.6', None, IpamRowStatus.FREE, None, None)
+
+
+def test_build_subnet_ips_xlsx_emits_header_only_when_no_rows() -> None:
+    """With no exportable IPs the workbook still carries just the header row"""
+    with patch(f'{MODULE}.build_subnet_ip_export_rows', return_value=[]):
+        content: bytes = build_subnet_ips_xlsx(MagicMock(), MagicMock(), 7)
+
+    rows: list[tuple[Any, ...]] = list(load_workbook(BytesIO(content)).active.iter_rows(values_only=True))
+
+    assert rows == [tuple(IpamSubnetIpsExport.HEADERS)]

--- a/tests/unit/framework/ipam/test_subnet_options.py
+++ b/tests/unit/framework/ipam/test_subnet_options.py
@@ -1,0 +1,263 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for cmdb.framework.ipam.subnet_options
+
+Covers the two pure filter helpers (family equality, name / CIDR substring search with the
+shared activation rule) and the orchestrator build_subnet_options_page. For the orchestrator
+the loader is patched at the module path; node shaping, family resolution and display-order
+sorting are exercised for real through subnet_tree_node / sort_tree_nodes, which have their
+own dedicated tests in test_tree_overview
+"""
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from cmdb.models.object_model import CmdbObjectKey, CmdbObjectFieldKey
+from cmdb.models.special_type_model.special_type_enum import SpecialType
+from cmdb.models.special_type_model.ipam_constants import (
+    SubnetField,
+    IpAddressFamily,
+    IpamPagination,
+    IpamSearch,
+    IpamOverviewKey,
+    IpamTreeKey,
+)
+from cmdb.framework.ipam.subnet_options import (
+    build_subnet_options_page,
+    filter_nodes_by_family,
+    filter_nodes_by_search,
+)
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+SUBNET_TYPE_ID: int = 11
+SUBNET_OBJECT_ID_A: int = 201
+SUBNET_OBJECT_ID_B: int = 202
+SUBNET_OBJECT_ID_C: int = 203
+
+SUBNET_RANGE_V4_LOW: str = '10.1.0.0/16'
+SUBNET_RANGE_V4_HIGH: str = '10.2.0.0/16'
+SUBNET_RANGE_V6: str = '2001:db8::/48'
+UNPARSABLE_RANGE: str = 'not-a-cidr'
+
+SUBNET_NAME_A: str = 'Core'
+SUBNET_NAME_B: str = 'Mgmt'
+
+PATH: str = 'cmdb.framework.ipam.subnet_options'
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   FIXTURES                                                           #
+# -------------------------------------------------------------------------------------------------------------------- #
+def _make_node(
+    public_id: int,
+    cidr: Any = None,
+    family: str = IpAddressFamily.IPV4,
+    name: Any = None,
+) -> dict[str, Any]:
+    """Builds an already-shaped subnet option node for the filter helpers."""
+    return {
+        CmdbObjectKey.PUBLIC_ID: public_id,
+        IpamTreeKey.NAME: name,
+        IpamTreeKey.CIDR: cidr,
+        IpamTreeKey.TYPE: family,
+    }
+
+
+def _make_subnet_doc(
+    public_id: int,
+    network_range: Any = None,
+    name: Any = None,
+    subnet_type: Any = None,
+) -> dict[str, Any]:
+    """Builds a SUBNET CmdbObject doc with optional range / name / type-selector fields."""
+    fields: list[dict[str, Any]] = []
+
+    if network_range is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SubnetField.NETWORK_RANGE, CmdbObjectFieldKey.VALUE: network_range})
+
+    if name is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SubnetField.NAME, CmdbObjectFieldKey.VALUE: name})
+
+    if subnet_type is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SubnetField.TYPE, CmdbObjectFieldKey.VALUE: subnet_type})
+
+    return {
+        CmdbObjectKey.PUBLIC_ID: public_id,
+        CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID,
+        CmdbObjectKey.FIELDS: fields,
+    }
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              filter_nodes_by_family                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_filter_nodes_by_family_keeps_only_the_requested_family() -> None:
+    """Only nodes whose 'type' equals the requested family survive the filter"""
+    v4 = _make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_V4_LOW)
+    v6 = _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_V6, family=IpAddressFamily.IPV6)
+
+    assert filter_nodes_by_family([v4, v6], IpAddressFamily.IPV6) == [v6]
+    assert filter_nodes_by_family([v4, v6], IpAddressFamily.IPV4) == [v4]
+
+
+def test_filter_nodes_by_family_deactivates_on_empty_token() -> None:
+    """An empty family token returns every node in a new list"""
+    nodes = [
+        _make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_V4_LOW),
+        _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_V6, family=IpAddressFamily.IPV6),
+    ]
+
+    result = filter_nodes_by_family(nodes, '')
+
+    assert result == nodes
+    assert result is not nodes
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              filter_nodes_by_search                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_filter_nodes_by_search_matches_name_and_cidr_case_insensitively() -> None:
+    """The needle matches against the name OR the CIDR, ignoring case"""
+    by_name = _make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_V4_LOW, name=SUBNET_NAME_A)
+    by_cidr = _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_V6, family=IpAddressFamily.IPV6)
+    no_hit = _make_node(SUBNET_OBJECT_ID_C, SUBNET_RANGE_V4_HIGH, name=SUBNET_NAME_B)
+
+    assert filter_nodes_by_search([by_name, by_cidr, no_hit], 'cOrE') == [by_name]
+    assert filter_nodes_by_search([by_name, by_cidr, no_hit], 'db8') == [by_cidr]
+
+
+def test_filter_nodes_by_search_deactivates_below_min_query_length() -> None:
+    """Queries shorter than IpamSearch.MIN_QUERY_LENGTH (after stripping) return every node"""
+    nodes = [_make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_V4_LOW, name=SUBNET_NAME_A)]
+    short_query: str = 'x' * (IpamSearch.MIN_QUERY_LENGTH - 1)
+
+    assert filter_nodes_by_search(nodes, short_query) == nodes
+    assert filter_nodes_by_search(nodes, '   ') == nodes
+
+
+def test_filter_nodes_by_search_skips_nodes_without_name_and_cidr() -> None:
+    """A node whose name and cidr are both None never matches an active search"""
+    bare = _make_node(SUBNET_OBJECT_ID_A)
+
+    assert not filter_nodes_by_search([bare], SUBNET_NAME_A)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            build_subnet_options_page                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_build_subnet_options_page_loads_subnets_and_shapes_sorted_rows() -> None:
+    """All SUBNET objects are loaded once and come back as sorted lightweight option rows"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    docs = [
+        _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=SUBNET_RANGE_V4_HIGH),
+        _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_V4_LOW, name=SUBNET_NAME_A),
+    ]
+
+    with patch(f'{PATH}.load_all_special_type_objects', return_value=docs) as mock_load:
+        result = build_subnet_options_page(
+            objects_manager, types_manager, page=1, page_size=10, search='',
+        )
+
+    mock_load.assert_called_once_with(objects_manager, types_manager, SpecialType.SUBNET)
+    assert result[IpamOverviewKey.TOTAL] == 2
+    assert [r[CmdbObjectKey.PUBLIC_ID] for r in result[IpamOverviewKey.ROWS]] == [
+        SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_B,
+    ]
+    assert result[IpamOverviewKey.ROWS][0] == {
+        CmdbObjectKey.PUBLIC_ID: SUBNET_OBJECT_ID_A,
+        IpamTreeKey.NAME: SUBNET_NAME_A,
+        IpamTreeKey.CIDR: SUBNET_RANGE_V4_LOW,
+        IpamTreeKey.TYPE: IpAddressFamily.IPV4,
+    }
+
+
+def test_build_subnet_options_page_filters_by_family_cidr_first() -> None:
+    """The family filter uses the CIDR-first resolution: a v6 CIDR with a v4 selector is ipv6"""
+    contradicting = _make_subnet_doc(
+        SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_V6, subnet_type=IpAddressFamily.IPV4,
+    )
+    legacy_default = _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=UNPARSABLE_RANGE)
+    plain_v4 = _make_subnet_doc(SUBNET_OBJECT_ID_C, network_range=SUBNET_RANGE_V4_LOW)
+
+    with patch(f'{PATH}.load_all_special_type_objects', return_value=[contradicting, legacy_default, plain_v4]):
+        v6_page = build_subnet_options_page(
+            MagicMock(), MagicMock(), page=1, page_size=10, search='', family=IpAddressFamily.IPV6,
+        )
+        v4_page = build_subnet_options_page(
+            MagicMock(), MagicMock(), page=1, page_size=10, search='', family=IpAddressFamily.IPV4,
+        )
+
+    assert [r[CmdbObjectKey.PUBLIC_ID] for r in v6_page[IpamOverviewKey.ROWS]] == [SUBNET_OBJECT_ID_A]
+    assert [r[CmdbObjectKey.PUBLIC_ID] for r in v4_page[IpamOverviewKey.ROWS]] == [
+        SUBNET_OBJECT_ID_C, SUBNET_OBJECT_ID_B,
+    ]
+    assert v6_page[IpamOverviewKey.TYPE] == IpAddressFamily.IPV6
+
+
+def test_build_subnet_options_page_applies_search_after_the_family_filter() -> None:
+    """total reflects the post-filter count; search narrows within the family selection"""
+    match = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_V4_LOW, name=SUBNET_NAME_A)
+    no_match = _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=SUBNET_RANGE_V4_HIGH, name=SUBNET_NAME_B)
+    wrong_family = _make_subnet_doc(SUBNET_OBJECT_ID_C, network_range=SUBNET_RANGE_V6, name=SUBNET_NAME_A)
+
+    with patch(f'{PATH}.load_all_special_type_objects', return_value=[match, no_match, wrong_family]):
+        result = build_subnet_options_page(
+            MagicMock(), MagicMock(), page=1, page_size=10,
+            search=SUBNET_NAME_A, family=IpAddressFamily.IPV4,
+        )
+
+    assert result[IpamOverviewKey.TOTAL] == 1
+    assert [r[CmdbObjectKey.PUBLIC_ID] for r in result[IpamOverviewKey.ROWS]] == [SUBNET_OBJECT_ID_A]
+    assert result[IpamOverviewKey.SEARCH] == SUBNET_NAME_A
+
+
+def test_build_subnet_options_page_clamps_pagination_and_slices() -> None:
+    """An out-of-range page resolves to the last valid page; the slice honours page_size"""
+    docs = [
+        _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_V4_LOW),
+        _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=SUBNET_RANGE_V4_HIGH),
+        _make_subnet_doc(SUBNET_OBJECT_ID_C, network_range=SUBNET_RANGE_V6),
+    ]
+
+    with patch(f'{PATH}.load_all_special_type_objects', return_value=docs):
+        result = build_subnet_options_page(
+            MagicMock(), MagicMock(), page=99, page_size=2, search='',
+        )
+
+    assert result[IpamOverviewKey.PAGE] == 2
+    assert result[IpamOverviewKey.PAGE_SIZE] == 2
+    assert result[IpamOverviewKey.TOTAL] == 3
+    assert [r[CmdbObjectKey.PUBLIC_ID] for r in result[IpamOverviewKey.ROWS]] == [SUBNET_OBJECT_ID_C]
+
+
+def test_build_subnet_options_page_collapses_to_empty_envelope_without_subnets() -> None:
+    """No SUBNET objects (or no SUBNET CmdbType) yields an empty page envelope, no error"""
+    with patch(f'{PATH}.load_all_special_type_objects', return_value=[]):
+        result = build_subnet_options_page(
+            MagicMock(), MagicMock(),
+            page=1, page_size=IpamPagination.DEFAULT_PAGE_SIZE, search='',
+        )
+
+    assert result == {
+        IpamOverviewKey.PAGE: 1,
+        IpamOverviewKey.PAGE_SIZE: IpamPagination.DEFAULT_PAGE_SIZE,
+        IpamOverviewKey.TOTAL: 0,
+        IpamOverviewKey.SEARCH: '',
+        IpamOverviewKey.TYPE: '',
+        IpamOverviewKey.ROWS: [],
+    }

--- a/tests/unit/framework/ipam/test_subnet_overview.py
+++ b/tests/unit/framework/ipam/test_subnet_overview.py
@@ -49,6 +49,7 @@ from cmdb.models.special_type_model.ipam_constants import (
     IpamBucketLabel,
     IpamSortColumn,
     IpamSortDirection,
+    IpamSubnetIpsExport,
 )
 from cmdb.models.type_model.type_schema_key_enum import TypeSchemaKey
 from cmdb.framework.ipam.subnet_overview import (
@@ -80,8 +81,13 @@ from cmdb.framework.ipam.subnet_overview import (
     _sort_candidate_ips,
     _sorted_assigned_ips,
     _sorted_invalid_ips,
+    _require_sector_grid,
+    _resolve_sector_bounds,
+    _abort_if_export_too_big,
     build_invalid_subnet_overview,
     build_subnet_overview,
+    build_subnet_sector_ips,
+    build_subnet_ip_export_rows,
     list_all_assignable_ips,
     list_assignable_ips_matching_substring,
 )
@@ -2871,3 +2877,223 @@ def test_build_subnet_overview_ipv6_is_assigned_only_with_family_and_null_percen
     labels = [b[IpamOverviewKey.LABEL] for b in payload[IpamOverviewKey.TYPE_DISTRIBUTION]]
     assert IpamBucketLabel.FREE not in labels
     assert all(b[IpamOverviewKey.PERCENTAGE] is None for b in payload[IpamOverviewKey.TYPE_DISTRIBUTION])
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          SINGLE-SECTOR DRILL-DOWN                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_require_sector_grid_returns_sector_size_for_slash_24() -> None:
+    """A /24 fills the full 4x16 grid; the sector size is 256 / 64 = 4 addresses"""
+    assert _require_sector_grid(SUBNET_OBJECT_ID, IPv4Network('10.0.0.0/24')) == 4
+
+
+def test_require_sector_grid_aborts_when_subnet_too_small() -> None:
+    """A /27 cannot fill the full grid, so there are no clickable sectors -> 400"""
+    with pytest.raises(HTTPException) as exc_info:
+        _require_sector_grid(SUBNET_OBJECT_ID, IPv4Network('10.0.0.0/27'))
+
+    assert exc_info.value.code == 400
+
+
+def test_resolve_sector_bounds_returns_inclusive_window_for_aligned_start() -> None:
+    """An aligned start yields the [lo, hi] integer window of that sector"""
+    network = IPv4Network('10.0.0.0/24')
+    lo, hi = _resolve_sector_bounds(network, '10.0.0.4', sector_size=4)
+
+    assert (lo, hi) == (int(IPv4Address('10.0.0.4')), int(IPv4Address('10.0.0.7')))
+
+
+def test_resolve_sector_bounds_aborts_for_unaligned_start() -> None:
+    """A start that is not on a sector boundary aborts 400"""
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_sector_bounds(IPv4Network('10.0.0.0/24'), '10.0.0.5', sector_size=4)
+
+    assert exc_info.value.code == 400
+
+
+def test_resolve_sector_bounds_aborts_for_wrong_family_or_out_of_range() -> None:
+    """A cross-family start, an out-of-subnet start, or an unparsable string all abort 400"""
+    network = IPv4Network('10.0.0.0/24')
+
+    for bad_start in ('2001:db8::', '192.168.1.0', 'nonsense'):
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_sector_bounds(network, bad_start, sector_size=4)
+        assert exc_info.value.code == 400
+
+
+def test_build_subnet_sector_ips_ipv4_lists_assignable_window_free_and_assigned() -> None:
+    """An IPv4 mid sector lists its assignable addresses (free + assigned), echoing the window"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, SUBNET_RANGE)  # 10.0.0.0/24 -> sector_size 4
+    assigned = {'10.0.0.5': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None, is_valid=True)}
+    objects_manager = MagicMock()
+    objects_manager.get_summary_line.return_value = 'Server: web01'
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         patch(f'{PATH}._load_assigned_rows_map', return_value=assigned), \
+         patch(f'{PATH}._resolve_type_meta', return_value={OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server'}}):
+        payload = build_subnet_sector_ips(objects_manager, MagicMock(), SUBNET_OBJECT_ID, '10.0.0.4')
+
+    assert payload[IpamOverviewKey.SECTOR] == {
+        IpamOverviewKey.IP_START: '10.0.0.4', IpamOverviewKey.IP_END: '10.0.0.7',
+    }
+    ips = payload[IpamOverviewKey.IPS]
+    assert ips[IpamOverviewKey.TOTAL] == 4
+    assert [r[IpamOverviewKey.IP] for r in ips[IpamOverviewKey.ROWS]] == \
+        ['10.0.0.4', '10.0.0.5', '10.0.0.6', '10.0.0.7']
+    statuses = {r[IpamOverviewKey.IP]: r[IpamOverviewKey.STATUS] for r in ips[IpamOverviewKey.ROWS]}
+    assert statuses['10.0.0.5'] == IpamRowStatus.ASSIGNED
+    assert statuses['10.0.0.4'] == IpamRowStatus.FREE
+
+
+def test_build_subnet_sector_ips_ipv4_first_sector_excludes_network_address() -> None:
+    """The first sector clamps to the assignable range, dropping the network address"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, SUBNET_RANGE)
+    objects_manager = MagicMock()
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         patch(f'{PATH}._load_assigned_rows_map', return_value={}), \
+         patch(f'{PATH}._resolve_type_meta', return_value={}):
+        payload = build_subnet_sector_ips(objects_manager, MagicMock(), SUBNET_OBJECT_ID, '10.0.0.0')
+
+    ips = payload[IpamOverviewKey.IPS]
+    assert ips[IpamOverviewKey.TOTAL] == 3  # .0 (network) excluded, .1 .2 .3 remain
+    assert [r[IpamOverviewKey.IP] for r in ips[IpamOverviewKey.ROWS]] == ['10.0.0.1', '10.0.0.2', '10.0.0.3']
+
+
+def test_build_subnet_sector_ips_ipv6_is_assigned_only_within_the_sector() -> None:
+    """An IPv6 sector lists only the assigned addresses inside its window (no free enumeration)"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, '2001:db8::/64')  # sector_size 2**58
+    # '2001:db8::5' is in sector 0; the all-ffff host is in the last sector
+    in_sector_0 = _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None, is_valid=True)
+    in_last_sector = _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, None, is_valid=True)
+    assigned = {'2001:db8::5': in_sector_0, '2001:db8::ffff:ffff:ffff:ffff': in_last_sector}
+    objects_manager = MagicMock()
+    objects_manager.get_summary_line.return_value = 'Server: web01'
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         patch(f'{PATH}._load_assigned_rows_map', return_value=assigned), \
+         patch(f'{PATH}._resolve_type_meta', return_value={OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server'}}):
+        payload = build_subnet_sector_ips(objects_manager, MagicMock(), SUBNET_OBJECT_ID, '2001:db8::')
+
+    ips = payload[IpamOverviewKey.IPS]
+    assert ips[IpamOverviewKey.TOTAL] == 1
+    assert [r[IpamOverviewKey.IP] for r in ips[IpamOverviewKey.ROWS]] == ['2001:db8::5']
+
+
+def test_build_subnet_sector_ips_aborts_for_subnet_without_grid() -> None:
+    """A subnet too small to expose a grid aborts 400 (no sectors to drill into)"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, '10.0.0.0/27')
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         pytest.raises(HTTPException) as exc_info:
+        build_subnet_sector_ips(MagicMock(), MagicMock(), SUBNET_OBJECT_ID, '10.0.0.0')
+
+    assert exc_info.value.code == 400
+
+
+def test_build_subnet_sector_ips_aborts_for_misaligned_sector_start() -> None:
+    """A sector_start that is not a sector boundary aborts 400"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, SUBNET_RANGE)
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         patch(f'{PATH}._load_assigned_rows_map', return_value={}), \
+         patch(f'{PATH}._resolve_type_meta', return_value={}), \
+         pytest.raises(HTTPException) as exc_info:
+        build_subnet_sector_ips(MagicMock(), MagicMock(), SUBNET_OBJECT_ID, '10.0.0.5')
+
+    assert exc_info.value.code == 400
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          _abort_if_export_too_big                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_abort_if_export_too_big_raises_400_over_the_limit() -> None:
+    """One row over IpamSubnetIpsExport.MAX_EXPORT_ROWS aborts 400"""
+    with pytest.raises(HTTPException) as exc_info:
+        _abort_if_export_too_big(SUBNET_OBJECT_ID, IpamSubnetIpsExport.MAX_EXPORT_ROWS + 1)
+
+    assert exc_info.value.code == 400
+
+
+def test_abort_if_export_too_big_allows_the_limit_exactly() -> None:
+    """Exactly MAX_EXPORT_ROWS rows is allowed (the guard returns without raising)"""
+    assert _abort_if_export_too_big(SUBNET_OBJECT_ID, IpamSubnetIpsExport.MAX_EXPORT_ROWS) is None
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                        build_subnet_ip_export_rows                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_build_subnet_ip_export_rows_ipv4_emits_free_and_assigned() -> None:
+    """An IPv4 subnet exports every assignable address (free + assigned) in ascending IP order"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, SUBNET_RANGE)
+    assigned = {'10.0.0.5': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, 'aa:bb:cc:dd:ee:ff')}
+    type_meta = {OWNER_TYPE_ID: {IpamOverviewKey.LABEL: 'Server', IpamOverviewKey.CI_EXPLORER_COLOR: '#FF0000'}}
+    objects_manager = MagicMock()
+    objects_manager.get_summary_line.return_value = 'Server: web01'
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         patch(f'{PATH}._load_assigned_rows_map', return_value=assigned), \
+         patch(f'{PATH}._resolve_type_meta', return_value=type_meta):
+        rows = build_subnet_ip_export_rows(objects_manager, MagicMock(), SUBNET_OBJECT_ID)
+
+    # /24 has 254 assignable addresses (network + broadcast excluded)
+    assert len(rows) == 254
+    assert rows[0][IpamOverviewKey.IP] == '10.0.0.1'
+    assigned_rows = [r for r in rows if r[IpamOverviewKey.STATUS] == IpamRowStatus.ASSIGNED]
+    assert [r[IpamOverviewKey.IP] for r in assigned_rows] == ['10.0.0.5']
+    assert assigned_rows[0][IpamOverviewKey.TYPE_INFO][IpamOverviewKey.LABEL] == 'Server'
+
+
+def test_build_subnet_ip_export_rows_ipv6_emits_assigned_only() -> None:
+    """An IPv6 subnet exports only its in-CIDR assigned addresses (no free rows, no out-of-CIDR rows)"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, '2001:db8::/64')
+    assigned = {
+        '2001:db8::20': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, 'aa:bb:cc:dd:ee:01'),
+        '2001:db8::5': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, 'aa:bb:cc:dd:ee:02'),
+        '2002:db8::9': _make_assigned_entry(OWNER_OBJECT_ID, OWNER_TYPE_ID, 'x', is_valid=False),
+    }
+    objects_manager = MagicMock()
+    objects_manager.get_summary_line.return_value = 'Server: web01'
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         patch(f'{PATH}._load_assigned_rows_map', return_value=assigned), \
+         patch(f'{PATH}._resolve_type_meta', return_value={}):
+        rows = build_subnet_ip_export_rows(objects_manager, MagicMock(), SUBNET_OBJECT_ID)
+
+    # only the two in-CIDR assigned IPs, ascending; the out-of-CIDR (invalid) row is excluded
+    assert [r[IpamOverviewKey.IP] for r in rows] == ['2001:db8::5', '2001:db8::20']
+    assert all(r[IpamOverviewKey.STATUS] == IpamRowStatus.ASSIGNED for r in rows)
+
+
+def test_build_subnet_ip_export_rows_aborts_400_when_ipv4_too_big_without_enumerating() -> None:
+    """A large IPv4 subnet aborts 400 on the cheap assignable count, never enumerating the space"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, '10.0.0.0/20')  # 4094 assignable > 2500
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         patch(f'{PATH}._load_assigned_rows_map', return_value={}), \
+         patch(f'{PATH}.list_all_assignable_ips') as mock_enumerate, \
+         pytest.raises(HTTPException) as exc_info:
+        build_subnet_ip_export_rows(MagicMock(), MagicMock(), SUBNET_OBJECT_ID)
+
+    assert exc_info.value.code == 400
+    mock_enumerate.assert_not_called()
+
+
+def test_build_subnet_ip_export_rows_aborts_400_when_range_unparsable() -> None:
+    """A subnet whose network range is missing / unparsable aborts 400"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, 'not-a-cidr')
+
+    with patch(f'{PATH}._load_subnet_object', return_value=subnet_doc), \
+         pytest.raises(HTTPException) as exc_info:
+        build_subnet_ip_export_rows(MagicMock(), MagicMock(), SUBNET_OBJECT_ID)
+
+    assert exc_info.value.code == 400
+
+
+def test_build_subnet_ip_export_rows_propagates_load_subnet_aborts() -> None:
+    """An abort raised by _load_subnet_object (missing / non-subnet object) propagates out"""
+    with patch(f'{PATH}._load_subnet_object', side_effect=NotFound('not found')), \
+         pytest.raises(HTTPException) as exc_info:
+        build_subnet_ip_export_rows(MagicMock(), MagicMock(), SUBNET_OBJECT_ID)
+
+    assert exc_info.value.code == 404

--- a/tests/unit/framework/ipam/test_subnet_unassign.py
+++ b/tests/unit/framework/ipam/test_subnet_unassign.py
@@ -44,15 +44,20 @@ from cmdb.models.special_type_model.ipam_constants import (
     InterfaceField,
     IpamSection,
     IpamUnassignKey,
+    IpamUnassignMode,
 )
 from cmdb.models.type_model.type_schema_key_enum import TypeSchemaKey
 from cmdb.security.acl.permission import AccessControlPermission
 from cmdb.framework.ipam.subnet_unassign import (
+    _resolve_unassign_mode,
+    apply_unassign_to_owners,
     assert_subnet_exists,
     clear_subnet_ref_in_owner,
     clear_subnet_ref_in_owners,
     clear_subnet_ref_in_rows,
     collect_present_ips,
+    delete_subnet_rows,
+    delete_subnet_rows_in_owner,
     load_interface_owners,
     normalize_ip_list,
     parse_subnet_network,
@@ -626,7 +631,7 @@ def test_unassign_ips_from_subnet_aborts_400_when_any_requested_ip_is_not_assign
 
 
 def test_unassign_ips_from_subnet_returns_response_envelope_on_happy_path() -> None:
-    """Happy path returns the {ips, unassigned_count} envelope with deduped input order"""
+    """Happy path returns the {ips, mode, unassigned_count} envelope with deduped input order"""
     subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, SUBNET_RANGE)
     owner = _make_owner(
         OWNER_OBJECT_ID,
@@ -644,8 +649,10 @@ def test_unassign_ips_from_subnet_returns_response_envelope_on_happy_path() -> N
             ['10.0.0.2', '10.0.0.1', '10.0.0.2'], MagicMock(),
         )
 
+    # mode defaults to 'reference' when raw_mode is omitted
     assert result == {
         IpamUnassignKey.IPS: ['10.0.0.2', '10.0.0.1'],
+        IpamUnassignKey.MODE: IpamUnassignMode.REFERENCE,
         IpamUnassignKey.UNASSIGNED_COUNT: 2,
     }
 
@@ -681,6 +688,113 @@ def test_unassign_ips_from_subnet_does_not_write_when_no_owner_matches() -> None
          pytest.raises(HTTPException) as exc_info:
         unassign_ips_from_subnet(
             objects_manager, MagicMock(), SUBNET_OBJECT_ID, ['10.0.0.1'], MagicMock(),
+        )
+
+    assert exc_info.value.code == 400
+    objects_manager.update_object.assert_not_called()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          UNASSIGN MODE (reference / row)                                            #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_resolve_unassign_mode_defaults_to_reference() -> None:
+    """A missing / empty mode falls back to REFERENCE (the original behaviour)"""
+    assert _resolve_unassign_mode(None) == IpamUnassignMode.REFERENCE
+    assert _resolve_unassign_mode('') == IpamUnassignMode.REFERENCE
+
+
+def test_resolve_unassign_mode_accepts_known_values() -> None:
+    """The two recognised tokens resolve to their enum members"""
+    assert _resolve_unassign_mode('reference') == IpamUnassignMode.REFERENCE
+    assert _resolve_unassign_mode('row') == IpamUnassignMode.ROW
+
+
+def test_resolve_unassign_mode_aborts_for_unknown_value() -> None:
+    """An unrecognised mode aborts HTTP 400"""
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_unassign_mode('delete-everything')
+
+    assert exc_info.value.code == 400
+
+
+def test_delete_subnet_rows_drops_only_matching_rows() -> None:
+    """delete_subnet_rows removes target rows entirely and keeps the rest, reporting removed IPs"""
+    rows = [
+        _make_interface_row(subnet_ref=SUBNET_OBJECT_ID, ip='10.0.0.1'),          # target
+        _make_interface_row(subnet_ref=SUBNET_OBJECT_ID, ip='10.0.0.9'),          # same subnet, non-target IP
+        _make_interface_row(subnet_ref=OTHER_SUBNET_OBJECT_ID, ip='10.0.0.1'),    # other subnet
+    ]
+
+    new_rows, removed = delete_subnet_rows(rows, SUBNET_OBJECT_ID, {'10.0.0.1'})
+
+    assert removed == {'10.0.0.1'}
+    assert len(new_rows) == 2  # the two non-target rows survive
+    assert rows[0] not in new_rows
+
+
+def test_delete_subnet_rows_in_owner_removes_rows_from_interface_section() -> None:
+    """delete_subnet_rows_in_owner drops the matching rows from the dg-ipam-interface section"""
+    owner = _make_owner(
+        OWNER_OBJECT_ID,
+        [
+            _make_interface_row(subnet_ref=SUBNET_OBJECT_ID, ip='10.0.0.1'),
+            _make_interface_row(subnet_ref=SUBNET_OBJECT_ID, ip='10.0.0.2'),
+        ],
+    )
+
+    new_doc, removed = delete_subnet_rows_in_owner(owner, SUBNET_OBJECT_ID, {'10.0.0.1'})
+
+    assert removed == {'10.0.0.1'}
+    section = new_doc[CmdbObjectKey.MULTI_DATA_SECTIONS][0]
+    assert len(section[CmdbObjectMdsKey.VALUES]) == 1
+
+
+def test_apply_unassign_to_owners_row_mode_deletes_and_writes() -> None:
+    """ROW mode deletes the matching rows and writes the owner back once per touched owner"""
+    owner = _make_owner(OWNER_OBJECT_ID, [_make_interface_row(subnet_ref=SUBNET_OBJECT_ID, ip='10.0.0.1')])
+    objects_manager = MagicMock()
+
+    count = apply_unassign_to_owners(
+        objects_manager, [owner], SUBNET_OBJECT_ID, {'10.0.0.1'}, MagicMock(), IpamUnassignMode.ROW,
+    )
+
+    assert count == 1
+    objects_manager.update_object.assert_called_once()
+    written_doc = objects_manager.update_object.call_args.args[1]
+    assert written_doc[CmdbObjectKey.MULTI_DATA_SECTIONS][0][CmdbObjectMdsKey.VALUES] == []
+
+
+def test_unassign_ips_from_subnet_row_mode_deletes_rows_and_echoes_mode() -> None:
+    """raw_mode='row' deletes the matched rows and the response echoes mode='row'"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, SUBNET_RANGE)
+    owner = _make_owner(OWNER_OBJECT_ID, [_make_interface_row(subnet_ref=SUBNET_OBJECT_ID, ip='10.0.0.1')])
+    objects_manager = MagicMock()
+
+    with patch(f'{PATH}.assert_subnet_exists', return_value=subnet_doc), \
+         patch(f'{PATH}.load_interface_owners', return_value=[owner]):
+        result = unassign_ips_from_subnet(
+            objects_manager, MagicMock(), SUBNET_OBJECT_ID, ['10.0.0.1'], MagicMock(), raw_mode='row',
+        )
+
+    assert result == {
+        IpamUnassignKey.IPS: ['10.0.0.1'],
+        IpamUnassignKey.MODE: IpamUnassignMode.ROW,
+        IpamUnassignKey.UNASSIGNED_COUNT: 1,
+    }
+    written_doc = objects_manager.update_object.call_args.args[1]
+    assert written_doc[CmdbObjectKey.MULTI_DATA_SECTIONS][0][CmdbObjectMdsKey.VALUES] == []
+
+
+def test_unassign_ips_from_subnet_aborts_for_unknown_mode_before_writing() -> None:
+    """An unknown mode aborts 400 and no owner write happens"""
+    subnet_doc = _make_subnet_doc(SUBNET_OBJECT_ID, SUBNET_RANGE)
+    objects_manager = MagicMock()
+
+    with patch(f'{PATH}.assert_subnet_exists', return_value=subnet_doc), \
+         patch(f'{PATH}.load_interface_owners', return_value=[]), \
+         pytest.raises(HTTPException) as exc_info:
+        unassign_ips_from_subnet(
+            objects_manager, MagicMock(), SUBNET_OBJECT_ID, ['10.0.0.1'], MagicMock(), raw_mode='bogus',
         )
 
     assert exc_info.value.code == 400

--- a/tests/unit/framework/ipam/test_supernet_overview.py
+++ b/tests/unit/framework/ipam/test_supernet_overview.py
@@ -63,8 +63,8 @@ from cmdb.framework.ipam.supernet_overview import (
     _filter_rows_by_network_substring,
     _index_children_by_parent,
     _ip_range,
-    _load_subnets_for_supernet,
-    _load_supernet_object,
+    load_subnets_for_supernet,
+    load_supernet_object,
     _paginate_rows,
     _parse_supernet_cidr,
     _percent,
@@ -73,15 +73,16 @@ from cmdb.framework.ipam.supernet_overview import (
     _select_invalid_listed_rows,
     _select_invalid_rows,
     _select_listed_rows,
-    _subnet_family,
+    subnet_family,
     _subnet_family_rank,
-    _supernet_family,
+    supernet_family,
     _summarize_supernet,
     build_invalid_subnet_overview,
     build_supernet_overview,
     build_supernet_subnet_children,
     compute_subnet_row,
     load_assigned_subnet_rows,
+    resolve_supernet_family,
     compute_supernet_summary,
     sort_and_link_subnets,
 )
@@ -352,20 +353,20 @@ def test_compute_subnet_row_keeps_usage_percent_for_ipv4() -> None:
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
-#                                               _subnet_family                                                        #
+#                                               subnet_family                                                        #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_subnet_family_derives_ipv6_from_ipv6_cidr() -> None:
     """A parsable IPv6 CIDR maps to IpAddressFamily.IPV6"""
     subnet = _make_subnet_doc(SUBNET_OBJECT_ID_A, '2001:db8::/32', subnet_type=IpAddressFamily.IPV6)
 
-    assert _subnet_family(subnet) == IpAddressFamily.IPV6
+    assert subnet_family(subnet) == IpAddressFamily.IPV6
 
 
 def test_subnet_family_derives_ipv4_from_ipv4_cidr() -> None:
     """A parsable IPv4 CIDR maps to IpAddressFamily.IPV4"""
     subnet = _make_subnet_doc(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A, subnet_type=IpAddressFamily.IPV4)
 
-    assert _subnet_family(subnet) == IpAddressFamily.IPV4
+    assert subnet_family(subnet) == IpAddressFamily.IPV4
 
 
 def test_subnet_family_prefers_cidr_over_mismatched_selector() -> None:
@@ -373,8 +374,8 @@ def test_subnet_family_prefers_cidr_over_mismatched_selector() -> None:
     ipv6_cidr_ipv4_selector = _make_subnet_doc(SUBNET_OBJECT_ID_A, '2001:db8::/48', subnet_type=IpAddressFamily.IPV4)
     ipv4_cidr_ipv6_selector = _make_subnet_doc(SUBNET_OBJECT_ID_B, SUBNET_RANGE_A, subnet_type=IpAddressFamily.IPV6)
 
-    assert _subnet_family(ipv6_cidr_ipv4_selector) == IpAddressFamily.IPV6
-    assert _subnet_family(ipv4_cidr_ipv6_selector) == IpAddressFamily.IPV4
+    assert subnet_family(ipv6_cidr_ipv4_selector) == IpAddressFamily.IPV6
+    assert subnet_family(ipv4_cidr_ipv6_selector) == IpAddressFamily.IPV4
 
 
 def test_subnet_family_derives_from_cidr_for_missing_or_unknown_selector() -> None:
@@ -383,9 +384,9 @@ def test_subnet_family_derives_from_cidr_for_missing_or_unknown_selector() -> No
     unknown = _make_subnet_doc(SUBNET_OBJECT_ID_B, SUBNET_RANGE_B, subnet_type='something-else')
     missing_v6 = _make_subnet_doc(SUBNET_OBJECT_ID_A, '2001:db8::/48')
 
-    assert _subnet_family(missing) == IpAddressFamily.IPV4
-    assert _subnet_family(unknown) == IpAddressFamily.IPV4
-    assert _subnet_family(missing_v6) == IpAddressFamily.IPV6
+    assert subnet_family(missing) == IpAddressFamily.IPV4
+    assert subnet_family(unknown) == IpAddressFamily.IPV4
+    assert subnet_family(missing_v6) == IpAddressFamily.IPV6
 
 
 def test_subnet_family_falls_back_to_selector_when_cidr_unparsable() -> None:
@@ -393,8 +394,8 @@ def test_subnet_family_falls_back_to_selector_when_cidr_unparsable() -> None:
     with_selector = _make_subnet_doc(SUBNET_OBJECT_ID_A, 'not-a-cidr', subnet_type=IpAddressFamily.IPV6)
     without_selector = _make_subnet_doc(SUBNET_OBJECT_ID_A, 'not-a-cidr')
 
-    assert _subnet_family(with_selector) == IpAddressFamily.IPV6
-    assert _subnet_family(without_selector) == IpAddressFamily.IPV4
+    assert subnet_family(with_selector) == IpAddressFamily.IPV6
+    assert subnet_family(without_selector) == IpAddressFamily.IPV4
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -512,21 +513,21 @@ def test_compute_supernet_summary_nulls_percentages_for_ipv6_degenerate_network(
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
-#                                               _supernet_family                                                      #
+#                                               supernet_family                                                      #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_supernet_family_prefers_cidr_over_mismatched_selector() -> None:
     """CIDR-first: a parsable CIDR decides the family even when the selector disagrees (fix #1)"""
     supernet = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE, supernet_type=IpAddressFamily.IPV6)
 
     # SUPERNET_RANGE is an IPv4 CIDR, so the family is ipv4 despite the ipv6 selector
-    assert _supernet_family(supernet) == IpAddressFamily.IPV4
+    assert supernet_family(supernet) == IpAddressFamily.IPV4
 
 
 def test_supernet_family_derives_from_cidr_when_selector_missing() -> None:
     """A missing selector on an IPv6 CIDR derives ipv6 from the actual range"""
     supernet = _make_supernet_doc(SUPERNET_OBJECT_ID, '2001:db8::/32')
 
-    assert _supernet_family(supernet) == IpAddressFamily.IPV6
+    assert supernet_family(supernet) == IpAddressFamily.IPV6
 
 
 def test_supernet_family_falls_back_to_selector_when_cidr_unparsable() -> None:
@@ -534,8 +535,8 @@ def test_supernet_family_falls_back_to_selector_when_cidr_unparsable() -> None:
     with_selector = _make_supernet_doc(SUPERNET_OBJECT_ID, 'not-a-cidr', supernet_type=IpAddressFamily.IPV6)
     without_selector = _make_supernet_doc(SUPERNET_OBJECT_ID, 'not-a-cidr')
 
-    assert _supernet_family(with_selector) == IpAddressFamily.IPV6
-    assert _supernet_family(without_selector) == IpAddressFamily.IPV4
+    assert supernet_family(with_selector) == IpAddressFamily.IPV6
+    assert supernet_family(without_selector) == IpAddressFamily.IPV4
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -1150,7 +1151,7 @@ def test_paginate_rows_returns_empty_page_for_empty_input() -> None:
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
-#                                            _load_supernet_object                                                     #
+#                                            load_supernet_object                                                     #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_load_supernet_object_aborts_400_when_supernet_type_not_defined() -> None:
     """No SUPERNET CmdbType → HTTP 400; no object query is issued"""
@@ -1159,7 +1160,7 @@ def test_load_supernet_object_aborts_400_when_supernet_type_not_defined() -> Non
     types_manager.get_one_by.return_value = None
 
     with pytest.raises(HTTPException) as exc_info:
-        _load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+        load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
 
     assert exc_info.value.code == 400
     objects_manager.find_objects.assert_not_called()
@@ -1173,7 +1174,7 @@ def test_load_supernet_object_aborts_404_when_object_not_found() -> None:
     types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUPERNET_TYPE_ID}
 
     with pytest.raises(HTTPException) as exc_info:
-        _load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+        load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
 
     assert exc_info.value.code == 404
 
@@ -1187,7 +1188,7 @@ def test_load_supernet_object_aborts_400_when_object_is_not_a_supernet() -> None
     types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUPERNET_TYPE_ID}
 
     with pytest.raises(HTTPException) as exc_info:
-        _load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+        load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
 
     assert exc_info.value.code == 400
 
@@ -1200,7 +1201,7 @@ def test_load_supernet_object_returns_candidate_on_happy_path() -> None:
     types_manager = MagicMock()
     types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUPERNET_TYPE_ID}
 
-    result = _load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+    result = load_supernet_object(objects_manager, types_manager, SUPERNET_OBJECT_ID)
 
     assert result is supernet_doc
     objects_manager.find_objects.assert_called_once_with(
@@ -1243,7 +1244,7 @@ def test_parse_supernet_cidr_returns_none_for_unparsable_string() -> None:
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
-#                                          _load_subnets_for_supernet                                                  #
+#                                          load_subnets_for_supernet                                                  #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_load_subnets_for_supernet_returns_empty_when_subnet_type_not_defined() -> None:
     """No SUBNET CmdbType → empty list, no DB query"""
@@ -1251,7 +1252,7 @@ def test_load_subnets_for_supernet_returns_empty_when_subnet_type_not_defined() 
     types_manager = MagicMock()
     types_manager.get_one_by.return_value = None
 
-    result = _load_subnets_for_supernet(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+    result = load_subnets_for_supernet(objects_manager, types_manager, SUPERNET_OBJECT_ID)
 
     assert result == []
     objects_manager.find_objects.assert_not_called()
@@ -1265,7 +1266,7 @@ def test_load_subnets_for_supernet_returns_manager_result_when_type_defined() ->
     types_manager = MagicMock()
     types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUBNET_TYPE_ID}
 
-    result = _load_subnets_for_supernet(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+    result = load_subnets_for_supernet(objects_manager, types_manager, SUPERNET_OBJECT_ID)
 
     assert result is subnet_docs
 
@@ -1277,7 +1278,7 @@ def test_load_subnets_for_supernet_queries_with_parent_supernet_field_filter() -
     types_manager = MagicMock()
     types_manager.get_one_by.return_value = {CmdbObjectKey.PUBLIC_ID: SUBNET_TYPE_ID}
 
-    _load_subnets_for_supernet(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+    load_subnets_for_supernet(objects_manager, types_manager, SUPERNET_OBJECT_ID)
 
     objects_manager.find_objects.assert_called_once_with(
         {
@@ -1466,14 +1467,14 @@ def test_attach_vlans_to_rows_isolates_each_rows_vlans_from_the_source_bucket() 
     assert bucket == [{CmdbObjectKey.PUBLIC_ID: VLAN_OBJECT_ID_X, IpamOverviewKey.NAME: VLAN_NAME_X}]
 
 
-def test_attach_vlans_to_rows_returns_none_and_mutates_in_place() -> None:
-    """The helper returns None; rows are mutated in place"""
+def test_attach_vlans_to_rows_mutates_in_place() -> None:
+    """The helper mutates each row in place, setting the VLANS key (returns nothing)"""
     row = _make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A)
 
-    result = _attach_vlans_to_rows([row], {})
+    _attach_vlans_to_rows([row], {})
 
-    assert result is None
     assert IpamOverviewKey.VLANS in row
+    assert row[IpamOverviewKey.VLANS] == []
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -1481,7 +1482,7 @@ def test_attach_vlans_to_rows_returns_none_and_mutates_in_place() -> None:
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_build_linked_subnet_rows_returns_empty_when_no_subnets_under_supernet() -> None:
     """No SUBNET docs → empty list (the count helper is also bypassed)"""
-    with patch(f'{PATH}._load_subnets_for_supernet', return_value=[]), \
+    with patch(f'{PATH}.load_subnets_for_supernet', return_value=[]), \
          patch(f'{PATH}._count_used_ips_per_subnet') as count_mock:
         result = _build_linked_subnet_rows(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1506,7 +1507,7 @@ def test_build_linked_subnet_rows_shapes_rows_and_links_parents() -> None:
         SUBNET_OBJECT_ID_A: [{CmdbObjectKey.PUBLIC_ID: VLAN_OBJECT_ID_X, IpamOverviewKey.NAME: VLAN_NAME_X}],
     }
 
-    with patch(f'{PATH}._load_subnets_for_supernet', return_value=subnet_objs), \
+    with patch(f'{PATH}.load_subnets_for_supernet', return_value=subnet_objs), \
          patch(f'{PATH}._count_used_ips_per_subnet', return_value=used_counts), \
          patch(f'{PATH}.load_vlans_by_subnets', return_value=vlans_by_subnet):
         result = _build_linked_subnet_rows(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
@@ -1564,8 +1565,8 @@ def test_summarize_supernet_forwards_none_network_and_family_unchanged() -> None
 #                                            _prepare_supernet_view                                                    #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_prepare_supernet_view_propagates_load_supernet_aborts() -> None:
-    """An abort raised by _load_supernet_object propagates out of the prep helper"""
-    with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
+    """An abort raised by load_supernet_object propagates out of the prep helper"""
+    with patch(f'{PATH}.load_supernet_object', side_effect=NotFound('not found')), \
          pytest.raises(HTTPException) as exc_info:
         _prepare_supernet_view(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1577,7 +1578,7 @@ def test_prepare_supernet_view_returns_four_tuple_with_expected_types() -> None:
     supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
     row_in = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_in]):
         returned_doc, rows, summary, invalid_count = _prepare_supernet_view(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID,
@@ -1597,7 +1598,7 @@ def test_build_supernet_overview_ipv6_summary_has_family_and_null_percentages() 
         IpamOverviewKey.USED_IPS: 5,
     }
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row]):
         payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1616,7 +1617,7 @@ def test_prepare_supernet_view_annotates_rows_with_has_children_and_is_valid_bef
     row_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.USED_IPS: 0}
     row_outside = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'), IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_valid, row_outside]):
         _, rows, _summary, _invalid = _prepare_supernet_view(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID,
@@ -1634,7 +1635,7 @@ def test_prepare_supernet_view_returns_invalid_count_matching_annotated_rows() -
     row_outside = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'), IpamOverviewKey.USED_IPS: 0}
     row_unparsable = {**_make_row(99, 'not-a-cidr'), IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(
              f'{PATH}._build_linked_subnet_rows',
              return_value=[row_valid, row_outside, row_unparsable],
@@ -1651,7 +1652,7 @@ def test_prepare_supernet_view_marks_every_row_invalid_when_supernet_cidr_unpars
     broken_supernet = _make_supernet_doc(SUPERNET_OBJECT_ID, 'not-a-cidr')
     row_in = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=broken_supernet), \
+    with patch(f'{PATH}.load_supernet_object', return_value=broken_supernet), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_in]):
         _, rows, _summary, invalid_count = _prepare_supernet_view(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID,
@@ -1665,8 +1666,8 @@ def test_prepare_supernet_view_marks_every_row_invalid_when_supernet_cidr_unpars
 #                                          build_supernet_overview                                                     #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_build_supernet_overview_propagates_load_supernet_aborts() -> None:
-    """An abort raised by _load_supernet_object propagates out of the orchestrator"""
-    with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
+    """An abort raised by load_supernet_object propagates out of the orchestrator"""
+    with patch(f'{PATH}.load_supernet_object', side_effect=NotFound('not found')), \
          pytest.raises(HTTPException) as exc_info:
         build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1683,7 +1684,7 @@ def test_build_supernet_overview_returns_payload_with_supernet_and_subnets_block
     row_b = {**_make_row(SUBNET_OBJECT_ID_B, SUBNET_RANGE_B), IpamOverviewKey.PARENT_ID: None,
              IpamOverviewKey.USED_IPS: 2}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_nested, row_b]):
         payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1706,7 +1707,7 @@ def test_build_supernet_overview_aggregates_total_used_across_all_subnets() -> N
     row_nested = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, NESTED_IN_A_RANGE),
                   IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 1}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_nested]):
         payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1724,7 +1725,7 @@ def test_build_supernet_overview_annotates_has_children_on_top_level_rows() -> N
     row_b = {**_make_row(SUBNET_OBJECT_ID_B, SUBNET_RANGE_B), IpamOverviewKey.PARENT_ID: None,
              IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_nested, row_b]):
         payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1741,7 +1742,7 @@ def test_build_supernet_overview_paginates_top_level_rows() -> None:
     row_b = {**_make_row(SUBNET_OBJECT_ID_B, SUBNET_RANGE_B), IpamOverviewKey.PARENT_ID: None,
              IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_b]):
         payload = build_supernet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, page=1, page_size=1,
@@ -1757,7 +1758,7 @@ def test_build_supernet_overview_returns_empty_rows_when_no_subnets_exist() -> N
     """When the supernet has zero subnets, the payload still emits the expected envelope"""
     supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[]):
         payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1776,7 +1777,7 @@ def test_build_supernet_overview_returns_flat_rows_across_nesting_depths_when_se
     row_top_b = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'), IpamOverviewKey.PARENT_ID: None,
                  IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_top_a, row_nested, row_top_b]):
         payload = build_supernet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, search='10.0.0',
@@ -1798,7 +1799,7 @@ def test_build_supernet_overview_kpi_summary_is_invariant_under_search_filter() 
                  IpamOverviewKey.USED_IPS: 2}
     all_rows = [row_top_a, row_nested, row_top_b]
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=all_rows):
         no_search = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
         with_search = build_supernet_overview(
@@ -1816,7 +1817,7 @@ def test_build_supernet_overview_falls_back_to_top_level_for_search_below_min_le
     row_nested = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, NESTED_IN_A_RANGE),
                   IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_top_a, row_nested]):
         payload = build_supernet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, search='1',
@@ -1834,7 +1835,7 @@ def test_build_supernet_overview_treats_whitespace_only_search_as_no_filter() ->
     row_nested = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, NESTED_IN_A_RANGE),
                   IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_top_a, row_nested]):
         payload = build_supernet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, search='   ',
@@ -1850,7 +1851,7 @@ def test_build_supernet_overview_returns_empty_rows_when_search_has_no_matches()
     row_top_a = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.PARENT_ID: None,
                  IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_top_a]):
         payload = build_supernet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, search='172.16',
@@ -1868,7 +1869,7 @@ def test_build_supernet_overview_paginates_flat_search_results() -> None:
     row_nested = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, NESTED_IN_A_RANGE),
                   IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_top_a, row_nested]):
         payload = build_supernet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, page=1, page_size=1, search='10.0',
@@ -1888,7 +1889,7 @@ def test_build_supernet_overview_annotates_is_valid_on_top_level_rows() -> None:
     row_outside = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'), IpamOverviewKey.PARENT_ID: None,
                    IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_inside, row_outside]):
         payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -1907,7 +1908,7 @@ def test_build_supernet_overview_invalid_count_reflects_all_nesting_depths() -> 
     row_top_invalid = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.1.0/24'),
                        IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(
              f'{PATH}._build_linked_subnet_rows',
              return_value=[row_top_valid, row_nested_invalid, row_top_invalid],
@@ -1925,7 +1926,7 @@ def test_build_supernet_overview_invalid_count_is_invariant_under_search() -> No
     row_invalid_b = {**_make_row(SUBNET_OBJECT_ID_B, '172.16.0.0/24'),
                      IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_invalid_a, row_invalid_b]):
         no_search = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
         with_search = build_supernet_overview(
@@ -1941,8 +1942,8 @@ def test_build_supernet_overview_invalid_count_is_invariant_under_search() -> No
 #                                       build_supernet_subnet_children                                                 #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_build_supernet_subnet_children_propagates_load_supernet_aborts() -> None:
-    """An abort raised by _load_supernet_object propagates out of the children orchestrator"""
-    with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
+    """An abort raised by load_supernet_object propagates out of the children orchestrator"""
+    with patch(f'{PATH}.load_supernet_object', side_effect=NotFound('not found')), \
          pytest.raises(HTTPException) as exc_info:
         build_supernet_subnet_children(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, SUBNET_OBJECT_ID_A)
 
@@ -1953,7 +1954,7 @@ def test_build_supernet_subnet_children_aborts_400_when_parent_subnet_not_under_
     """A subnet id that doesn't appear among the supernet's linked rows → HTTP 400"""
     supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[]), \
          pytest.raises(HTTPException) as exc_info:
         build_supernet_subnet_children(
@@ -1971,7 +1972,7 @@ def test_build_supernet_subnet_children_returns_direct_children_of_parent_subnet
     row_nested = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, NESTED_IN_A_RANGE),
                   IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_nested]):
         payload = build_supernet_subnet_children(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, SUBNET_OBJECT_ID_A,
@@ -1990,7 +1991,7 @@ def test_build_supernet_subnet_children_returns_empty_rows_when_subnet_has_no_ch
     row_a = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), IpamOverviewKey.PARENT_ID: None,
              IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a]):
         payload = build_supernet_subnet_children(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, SUBNET_OBJECT_ID_A,
@@ -2007,7 +2008,7 @@ def test_build_supernet_subnet_children_annotates_is_valid_on_child_rows() -> No
     child_inside = {**_make_row(SUBNET_OBJECT_ID_NESTED_IN_A, NESTED_IN_A_RANGE),
                     IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, child_inside]):
         payload = build_supernet_subnet_children(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, SUBNET_OBJECT_ID_A,
@@ -2026,7 +2027,7 @@ def test_load_assigned_subnet_rows_validates_then_returns_all_rows() -> None:
     supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, SUPERNET_RANGE)
     rows = [_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A), _make_row(SUBNET_OBJECT_ID_B, SUBNET_RANGE_B)]
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc) as mock_load, \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc) as mock_load, \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=rows):
         result = load_assigned_subnet_rows(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -2036,7 +2037,7 @@ def test_load_assigned_subnet_rows_validates_then_returns_all_rows() -> None:
 
 def test_load_assigned_subnet_rows_propagates_load_supernet_abort() -> None:
     """An abort raised while validating the supernet propagates out"""
-    with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
+    with patch(f'{PATH}.load_supernet_object', side_effect=NotFound('not found')), \
          pytest.raises(HTTPException):
         load_assigned_subnet_rows(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -2045,8 +2046,8 @@ def test_load_assigned_subnet_rows_propagates_load_supernet_abort() -> None:
 #                                       build_invalid_subnet_overview                                                  #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_build_invalid_subnet_overview_propagates_load_supernet_aborts() -> None:
-    """An abort raised by _load_supernet_object propagates out of the orchestrator"""
-    with patch(f'{PATH}._load_supernet_object', side_effect=NotFound('not found')), \
+    """An abort raised by load_supernet_object propagates out of the orchestrator"""
+    with patch(f'{PATH}.load_supernet_object', side_effect=NotFound('not found')), \
          pytest.raises(HTTPException) as exc_info:
         build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -2059,7 +2060,7 @@ def test_build_invalid_subnet_overview_returns_envelope_keys_matching_main_overv
     row_invalid = {**_make_row(SUBNET_OBJECT_ID_A, '192.168.0.0/24'),
                    IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_invalid]):
         payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -2082,7 +2083,7 @@ def test_build_invalid_subnet_overview_returns_only_invalid_subnets_in_rows() ->
                           IpamOverviewKey.PARENT_ID: SUBNET_OBJECT_ID_A,
                           IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(
              f'{PATH}._build_linked_subnet_rows',
              return_value=[row_valid, row_invalid_top, row_invalid_nested],
@@ -2100,7 +2101,7 @@ def test_build_invalid_subnet_overview_returns_empty_rows_when_every_subnet_is_v
     row_valid = {**_make_row(SUBNET_OBJECT_ID_A, SUBNET_RANGE_A),
                  IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_valid]):
         payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
@@ -2117,7 +2118,7 @@ def test_build_invalid_subnet_overview_kpi_summary_matches_main_overview() -> No
     row_invalid = {**_make_row(SUBNET_OBJECT_ID_B, '192.168.0.0/24'),
                    IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 2}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_valid, row_invalid]):
         main_payload = build_supernet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
         invalid_payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
@@ -2134,7 +2135,7 @@ def test_build_invalid_subnet_overview_paginates_the_invalid_list() -> None:
         {**_make_row(203, '192.168.2.0/24'), IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0},
     ]
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=invalid_rows):
         payload = build_invalid_subnet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, page=1, page_size=2,
@@ -2155,7 +2156,7 @@ def test_build_invalid_subnet_overview_search_filters_subnets_total_but_not_inva
     invalid_172 = {**_make_row(202, '172.16.0.0/24'),
                    IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=supernet_doc), \
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[invalid_192, invalid_172]):
         payload = build_invalid_subnet_overview(
             MagicMock(), MagicMock(), SUPERNET_OBJECT_ID, search='192.168',
@@ -2175,9 +2176,35 @@ def test_build_invalid_subnet_overview_marks_every_row_invalid_when_supernet_cid
     row_b = {**_make_row(SUBNET_OBJECT_ID_B, SUBNET_RANGE_B),
              IpamOverviewKey.PARENT_ID: None, IpamOverviewKey.USED_IPS: 0}
 
-    with patch(f'{PATH}._load_supernet_object', return_value=broken_supernet), \
+    with patch(f'{PATH}.load_supernet_object', return_value=broken_supernet), \
          patch(f'{PATH}._build_linked_subnet_rows', return_value=[row_a, row_b]):
         payload = build_invalid_subnet_overview(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
 
     assert payload[IpamOverviewKey.INVALID_COUNT] == 2
     assert payload[IpamOverviewKey.SUBNETS][IpamOverviewKey.TOTAL] == 2
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             resolve_supernet_family                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_resolve_supernet_family_loads_then_resolves_via_supernet_family() -> None:
+    """The supernet is loaded through the validating loader and its family resolved CIDR-first"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, '2001:db8::/32')
+
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc) as mock_load:
+        family = resolve_supernet_family(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+
+    mock_load.assert_called_once_with(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+    assert family == IpAddressFamily.IPV6
+
+
+def test_resolve_supernet_family_defaults_to_ipv4_without_cidr_or_selector() -> None:
+    """A supernet with neither parsable CIDR nor selector resolves to the IPv4 legacy default"""
+    supernet_doc = _make_supernet_doc(SUPERNET_OBJECT_ID, None)
+
+    with patch(f'{PATH}.load_supernet_object', return_value=supernet_doc):
+        family = resolve_supernet_family(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert family == IpAddressFamily.IPV4

--- a/tests/unit/framework/ipam/test_tree_overview.py
+++ b/tests/unit/framework/ipam/test_tree_overview.py
@@ -1,0 +1,514 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for cmdb.framework.ipam.tree_overview
+
+Covers the pure helpers (reference coercion, node shaping, display-order sorting, CIDR
+containment nesting), the type-scoped object loader (Mongo criteria pinned via
+assert_called_once_with) and the three orchestrators (build_ipam_tree,
+build_supernet_subnet_tree, build_unassigned_subnets). For the orchestrators the loaders are
+patched at the module path so each test verifies orchestration in isolation; the loaders have
+their own dedicated tests in this file. sort_tree_nodes exercises _tree_sort_key, so the key
+function is not tested directly
+"""
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from cmdb.models.object_model import CmdbObjectKey, CmdbObjectFieldKey
+from cmdb.models.special_type_model.special_type_enum import SpecialType
+from cmdb.models.special_type_model.ipam_constants import (
+    SubnetField,
+    SupernetField,
+    IpAddressFamily,
+    IpamTreeKey,
+)
+from cmdb.framework.ipam.tree_overview import (
+    _coerce_ref_id,
+    _collect_referenced_supernet_ids,
+    load_all_special_type_objects,
+    _parent_supernet_id,
+    subnet_tree_node,
+    _supernet_tree_node,
+    build_ipam_tree,
+    build_supernet_subnet_tree,
+    build_unassigned_subnets,
+    nest_subnet_nodes,
+    sort_tree_nodes,
+)
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+SUPERNET_TYPE_ID: int = 10
+SUBNET_TYPE_ID: int = 11
+SUPERNET_OBJECT_ID: int = 100
+SUBNET_OBJECT_ID_A: int = 201
+SUBNET_OBJECT_ID_B: int = 202
+SUBNET_OBJECT_ID_C: int = 203
+SUBNET_OBJECT_ID_D: int = 204
+
+SUPERNET_RANGE: str = '10.0.0.0/8'
+SUBNET_RANGE_BROAD: str = '10.1.0.0/16'
+SUBNET_RANGE_NESTED: str = '10.1.4.0/24'
+SUBNET_RANGE_SIBLING: str = '10.2.0.0/16'
+SUBNET_RANGE_V6: str = '2001:db8::/32'
+SUBNET_RANGE_V6_NONCANONICAL: str = '2001:DB8::/32'
+TIE_RANGE_NARROW: str = '10.0.0.0/16'
+UNPARSABLE_RANGE: str = 'not-a-cidr'
+
+SUPERNET_NAME: str = 'DC'
+SUBNET_NAME_A: str = 'Core'
+SUBNET_NAME_B: str = 'Mgmt'
+UNPARSABLE_NAME_FIRST: str = 'Alpha'
+UNPARSABLE_NAME_SECOND: str = 'beta'
+
+PATH: str = 'cmdb.framework.ipam.tree_overview'
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   FIXTURES                                                           #
+# -------------------------------------------------------------------------------------------------------------------- #
+def _make_subnet_doc(
+    public_id: int,
+    network_range: Any = None,
+    name: Any = None,
+    subnet_type: Any = None,
+    supernet_ref: Any = None,
+    include_ref_field: bool = False,
+) -> dict[str, Any]:
+    """Builds a SUBNET CmdbObject doc; the ref field is only present when given or forced."""
+    fields: list[dict[str, Any]] = []
+
+    if network_range is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SubnetField.NETWORK_RANGE, CmdbObjectFieldKey.VALUE: network_range})
+
+    if name is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SubnetField.NAME, CmdbObjectFieldKey.VALUE: name})
+
+    if subnet_type is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SubnetField.TYPE, CmdbObjectFieldKey.VALUE: subnet_type})
+
+    if supernet_ref is not None or include_ref_field:
+        fields.append({CmdbObjectFieldKey.NAME: SubnetField.PARENT_SUPERNET, CmdbObjectFieldKey.VALUE: supernet_ref})
+
+    return {
+        CmdbObjectKey.PUBLIC_ID: public_id,
+        CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID,
+        CmdbObjectKey.FIELDS: fields,
+    }
+
+
+def _make_supernet_doc(public_id: int, network_range: Any = None, name: Any = None) -> dict[str, Any]:
+    """Builds a SUPERNET CmdbObject doc with optional range and name fields."""
+    fields: list[dict[str, Any]] = []
+
+    if network_range is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SupernetField.NETWORK_RANGE, CmdbObjectFieldKey.VALUE: network_range})
+
+    if name is not None:
+        fields.append({CmdbObjectFieldKey.NAME: SupernetField.NAME, CmdbObjectFieldKey.VALUE: name})
+
+    return {
+        CmdbObjectKey.PUBLIC_ID: public_id,
+        CmdbObjectKey.TYPE_ID: SUPERNET_TYPE_ID,
+        CmdbObjectKey.FIELDS: fields,
+    }
+
+
+def _make_node(public_id: int, cidr: Any, family: str = IpAddressFamily.IPV4, name: Any = None) -> dict[str, Any]:
+    """Builds an already-shaped tree node for the sort / nest helpers."""
+    return {
+        CmdbObjectKey.PUBLIC_ID: public_id,
+        IpamTreeKey.NAME: name,
+        IpamTreeKey.CIDR: cidr,
+        IpamTreeKey.TYPE: family,
+    }
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                  _coerce_ref_id                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_coerce_ref_id_passes_ints_and_digit_strings_through() -> None:
+    """An int ref and a digit-string ref both coerce to the int public_id"""
+    assert _coerce_ref_id(SUPERNET_OBJECT_ID) == SUPERNET_OBJECT_ID
+    assert _coerce_ref_id(str(SUPERNET_OBJECT_ID)) == SUPERNET_OBJECT_ID
+
+
+def test_coerce_ref_id_treats_empty_markers_as_no_reference() -> None:
+    """None, the empty string and 0 all coerce to None (no usable reference)"""
+    assert _coerce_ref_id(None) is None
+    assert _coerce_ref_id('') is None
+    assert _coerce_ref_id(0) is None
+
+
+def test_coerce_ref_id_returns_none_for_garbage() -> None:
+    """A non-numeric string coerces to None instead of raising"""
+    assert _coerce_ref_id(UNPARSABLE_RANGE) is None
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                _parent_supernet_id                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_parent_supernet_id_reads_the_ref_field() -> None:
+    """A subnet with a numeric dg-supernet-ref resolves to that public_id"""
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID_A, supernet_ref=SUPERNET_OBJECT_ID)
+
+    assert _parent_supernet_id(doc) == SUPERNET_OBJECT_ID
+
+
+def test_parent_supernet_id_returns_none_when_field_missing_or_cleared() -> None:
+    """A missing ref field and a cleared (None) ref both count as unassigned"""
+    missing = _make_subnet_doc(SUBNET_OBJECT_ID_A)
+    cleared = _make_subnet_doc(SUBNET_OBJECT_ID_B, include_ref_field=True)
+
+    assert _parent_supernet_id(missing) is None
+    assert _parent_supernet_id(cleared) is None
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                         _collect_referenced_supernet_ids                                             #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_collect_referenced_supernet_ids_collects_coerced_refs_and_skips_unassigned() -> None:
+    """Numeric and digit-string refs land in the set; unassigned subnets contribute nothing"""
+    docs = [
+        _make_subnet_doc(SUBNET_OBJECT_ID_A, supernet_ref=SUPERNET_OBJECT_ID),
+        _make_subnet_doc(SUBNET_OBJECT_ID_B, supernet_ref=str(SUPERNET_OBJECT_ID + 1)),
+        _make_subnet_doc(SUBNET_OBJECT_ID_C),
+    ]
+
+    assert _collect_referenced_supernet_ids(docs) == {SUPERNET_OBJECT_ID, SUPERNET_OBJECT_ID + 1}
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                subnet_tree_node                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_subnet_tree_node_shapes_the_four_attributes() -> None:
+    """A well-formed subnet yields public_id, name, canonical cidr and the family under 'type'"""
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_BROAD, name=SUBNET_NAME_A)
+
+    assert subnet_tree_node(doc) == {
+        CmdbObjectKey.PUBLIC_ID: SUBNET_OBJECT_ID_A,
+        IpamTreeKey.NAME: SUBNET_NAME_A,
+        IpamTreeKey.CIDR: SUBNET_RANGE_BROAD,
+        IpamTreeKey.TYPE: IpAddressFamily.IPV4,
+    }
+
+
+def test_subnet_tree_node_normalises_the_cidr_to_canonical_form() -> None:
+    """A parsable but non-canonical IPv6 spelling is normalised via the parsed network"""
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_V6_NONCANONICAL)
+
+    assert subnet_tree_node(doc)[IpamTreeKey.CIDR] == SUBNET_RANGE_V6
+
+
+def test_subnet_tree_node_passes_unparsable_cidr_through_and_falls_back_to_selector() -> None:
+    """An unparsable range stays verbatim and the family comes from the selector field"""
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=UNPARSABLE_RANGE, subnet_type=IpAddressFamily.IPV6)
+    node = subnet_tree_node(doc)
+
+    assert node[IpamTreeKey.CIDR] == UNPARSABLE_RANGE
+    assert node[IpamTreeKey.TYPE] == IpAddressFamily.IPV6
+
+
+def test_subnet_tree_node_resolves_family_cidr_first() -> None:
+    """An IPv6 CIDR wins over a contradicting IPv4 selector value"""
+    doc = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_V6, subnet_type=IpAddressFamily.IPV4)
+
+    assert subnet_tree_node(doc)[IpamTreeKey.TYPE] == IpAddressFamily.IPV6
+
+
+def test_subnet_tree_node_nulls_missing_name_and_range() -> None:
+    """A subnet without name / range fields yields None for both and defaults to IPv4"""
+    node = subnet_tree_node(_make_subnet_doc(SUBNET_OBJECT_ID_A))
+
+    assert node[IpamTreeKey.NAME] is None
+    assert node[IpamTreeKey.CIDR] is None
+    assert node[IpamTreeKey.TYPE] == IpAddressFamily.IPV4
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               _supernet_tree_node                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_supernet_tree_node_sets_has_children_from_the_referenced_set() -> None:
+    """has_children is True iff the supernet's public_id appears in the referenced-id set"""
+    doc = _make_supernet_doc(SUPERNET_OBJECT_ID, network_range=SUPERNET_RANGE, name=SUPERNET_NAME)
+
+    with_children = _supernet_tree_node(doc, {SUPERNET_OBJECT_ID})
+    without_children = _supernet_tree_node(doc, set())
+
+    assert with_children[IpamTreeKey.HAS_CHILDREN] is True
+    assert without_children[IpamTreeKey.HAS_CHILDREN] is False
+    assert with_children[IpamTreeKey.CIDR] == SUPERNET_RANGE
+    assert with_children[IpamTreeKey.TYPE] == IpAddressFamily.IPV4
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                 sort_tree_nodes                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_sort_tree_nodes_groups_ipv4_before_ipv6() -> None:
+    """Every IPv4 node precedes every IPv6 node regardless of input order"""
+    v6 = _make_node(1, SUBNET_RANGE_V6, family=IpAddressFamily.IPV6)
+    v4 = _make_node(2, SUBNET_RANGE_BROAD)
+
+    assert sort_tree_nodes([v6, v4]) == [v4, v6]
+
+
+def test_sort_tree_nodes_orders_by_network_address_then_prefix_length() -> None:
+    """Within a family: ascending address, with the broader prefix first on an address tie"""
+    narrow_same_addr = _make_node(1, TIE_RANGE_NARROW)
+    broad_same_addr = _make_node(2, SUPERNET_RANGE)
+    higher_addr = _make_node(3, SUBNET_RANGE_BROAD)
+
+    result = sort_tree_nodes([higher_addr, narrow_same_addr, broad_same_addr])
+
+    assert [n[CmdbObjectKey.PUBLIC_ID] for n in result] == [2, 1, 3]
+
+
+def test_sort_tree_nodes_places_unparsable_nodes_last_within_their_family_by_name() -> None:
+    """Unparsable-CIDR nodes trail their family group, ordered case-insensitively by name"""
+    v4_parsable = _make_node(1, SUBNET_RANGE_BROAD)
+    v4_unparsable_b = _make_node(2, UNPARSABLE_RANGE, name=UNPARSABLE_NAME_SECOND)
+    v4_unparsable_a = _make_node(3, None, name=UNPARSABLE_NAME_FIRST)
+    v6_parsable = _make_node(4, SUBNET_RANGE_V6, family=IpAddressFamily.IPV6)
+
+    result = sort_tree_nodes([v6_parsable, v4_unparsable_b, v4_unparsable_a, v4_parsable])
+
+    assert [n[CmdbObjectKey.PUBLIC_ID] for n in result] == [1, 3, 2, 4]
+
+
+def test_sort_tree_nodes_does_not_mutate_the_input_list() -> None:
+    """The input list keeps its order; a new sorted list is returned"""
+    first = _make_node(1, SUBNET_RANGE_SIBLING)
+    second = _make_node(2, SUBNET_RANGE_BROAD)
+    nodes = [first, second]
+
+    result = sort_tree_nodes(nodes)
+
+    assert nodes == [first, second]
+    assert result == [second, first]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                nest_subnet_nodes                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_nest_subnet_nodes_nests_by_strict_cidr_containment() -> None:
+    """A /24 inside a /16 nests under it; an unrelated /16 stays a root sibling"""
+    broad = _make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_BROAD)
+    nested = _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_NESTED)
+    sibling = _make_node(SUBNET_OBJECT_ID_C, SUBNET_RANGE_SIBLING)
+
+    roots = nest_subnet_nodes([sibling, nested, broad])
+
+    assert [n[CmdbObjectKey.PUBLIC_ID] for n in roots] == [SUBNET_OBJECT_ID_A, SUBNET_OBJECT_ID_C]
+    assert broad[IpamTreeKey.CHILDREN] == [nested]
+    assert nested[IpamTreeKey.CHILDREN] == []
+    assert sibling[IpamTreeKey.CHILDREN] == []
+
+
+def test_nest_subnet_nodes_links_to_the_most_specific_enclosing_node() -> None:
+    """With /8 -> /16 -> /24 all present, the /24 nests under the /16, not the /8"""
+    top = _make_node(SUBNET_OBJECT_ID_A, SUPERNET_RANGE)
+    middle = _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_BROAD)
+    leaf = _make_node(SUBNET_OBJECT_ID_C, SUBNET_RANGE_NESTED)
+
+    roots = nest_subnet_nodes([leaf, top, middle])
+
+    assert roots == [top]
+    assert top[IpamTreeKey.CHILDREN] == [middle]
+    assert middle[IpamTreeKey.CHILDREN] == [leaf]
+
+
+def test_nest_subnet_nodes_treats_equal_cidrs_as_siblings() -> None:
+    """Two nodes with the identical CIDR do not nest into each other"""
+    first = _make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_BROAD)
+    duplicate = _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_BROAD)
+
+    roots = nest_subnet_nodes([first, duplicate])
+
+    assert len(roots) == 2
+    assert first[IpamTreeKey.CHILDREN] == []
+    assert duplicate[IpamTreeKey.CHILDREN] == []
+
+
+def test_nest_subnet_nodes_never_links_across_families() -> None:
+    """An IPv6 node stays a root next to IPv4 nodes and the roots keep IPv4 first"""
+    v4 = _make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_BROAD)
+    v6 = _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_V6, family=IpAddressFamily.IPV6)
+
+    roots = nest_subnet_nodes([v6, v4])
+
+    assert roots == [v4, v6]
+    assert v4[IpamTreeKey.CHILDREN] == []
+    assert v6[IpamTreeKey.CHILDREN] == []
+
+
+def test_nest_subnet_nodes_returns_unparsable_nodes_as_trailing_roots() -> None:
+    """A node without a parsable CIDR becomes a root with empty children, after parsable roots"""
+    parsable = _make_node(SUBNET_OBJECT_ID_A, SUBNET_RANGE_BROAD)
+    unparsable = _make_node(SUBNET_OBJECT_ID_B, UNPARSABLE_RANGE, name=SUBNET_NAME_B)
+
+    roots = nest_subnet_nodes([unparsable, parsable])
+
+    assert roots == [parsable, unparsable]
+    assert unparsable[IpamTreeKey.CHILDREN] == []
+
+
+def test_nest_subnet_nodes_keeps_children_in_ascending_cidr_order() -> None:
+    """Children of one parent come back ascending by network address"""
+    parent = _make_node(SUBNET_OBJECT_ID_A, SUPERNET_RANGE)
+    child_high = _make_node(SUBNET_OBJECT_ID_B, SUBNET_RANGE_SIBLING)
+    child_low = _make_node(SUBNET_OBJECT_ID_C, SUBNET_RANGE_BROAD)
+
+    nest_subnet_nodes([parent, child_high, child_low])
+
+    assert parent[IpamTreeKey.CHILDREN] == [child_low, child_high]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          load_all_special_type_objects                                              #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_load_all_special_type_objects_pins_the_type_id_criteria() -> None:
+    """The loader queries exactly {type_id: <resolved id>} with as_dict=True"""
+    objects_manager = MagicMock()
+    objects_manager.find_objects.return_value = []
+    types_manager = MagicMock()
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=SUBNET_TYPE_ID) as mock_resolve:
+        result = load_all_special_type_objects(objects_manager, types_manager, SpecialType.SUBNET)
+
+    mock_resolve.assert_called_once_with(types_manager, SpecialType.SUBNET)
+    objects_manager.find_objects.assert_called_once_with(
+        {CmdbObjectKey.TYPE_ID: SUBNET_TYPE_ID}, as_dict=True,
+    )
+    assert result == []
+
+
+def test_load_all_special_type_objects_returns_empty_when_type_undefined() -> None:
+    """An installation without the SpecialType yields [] without querying objects"""
+    objects_manager = MagicMock()
+
+    with patch(f'{PATH}.resolve_special_type_id', return_value=None):
+        result = load_all_special_type_objects(objects_manager, MagicMock(), SpecialType.SUPERNET)
+
+    assert result == []
+    objects_manager.find_objects.assert_not_called()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                 build_ipam_tree                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_build_ipam_tree_assembles_sorted_supernets_and_unassigned_blocks() -> None:
+    """Supernets carry has_children from the subnet refs; only unassigned subnets are listed"""
+    supernet_with = _make_supernet_doc(SUPERNET_OBJECT_ID, network_range=SUBNET_RANGE_SIBLING)
+    supernet_without = _make_supernet_doc(SUPERNET_OBJECT_ID + 1, network_range=SUBNET_RANGE_BROAD)
+    assigned = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_NESTED, supernet_ref=SUPERNET_OBJECT_ID)
+    orphan = _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=SUBNET_RANGE_BROAD)
+
+    with patch(
+        f'{PATH}.load_all_special_type_objects',
+        side_effect=[[supernet_with, supernet_without], [assigned, orphan]],
+    ) as mock_load:
+        tree = build_ipam_tree(MagicMock(), MagicMock())
+
+    assert mock_load.call_count == 2
+    assert [s[CmdbObjectKey.PUBLIC_ID] for s in tree[IpamTreeKey.SUPERNETS]] == [
+        SUPERNET_OBJECT_ID + 1, SUPERNET_OBJECT_ID,
+    ]
+    assert tree[IpamTreeKey.SUPERNETS][0][IpamTreeKey.HAS_CHILDREN] is False
+    assert tree[IpamTreeKey.SUPERNETS][1][IpamTreeKey.HAS_CHILDREN] is True
+    assert [s[CmdbObjectKey.PUBLIC_ID] for s in tree[IpamTreeKey.UNASSIGNED]] == [SUBNET_OBJECT_ID_B]
+
+
+def test_build_ipam_tree_loads_supernets_then_subnets() -> None:
+    """The two type-scoped loads request SUPERNET and SUBNET objects respectively"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+
+    with patch(f'{PATH}.load_all_special_type_objects', side_effect=[[], []]) as mock_load:
+        tree = build_ipam_tree(objects_manager, types_manager)
+
+    assert mock_load.call_args_list[0].args == (objects_manager, types_manager, SpecialType.SUPERNET)
+    assert mock_load.call_args_list[1].args == (objects_manager, types_manager, SpecialType.SUBNET)
+    assert tree == {IpamTreeKey.SUPERNETS: [], IpamTreeKey.UNASSIGNED: []}
+
+
+def test_build_ipam_tree_keeps_unassigned_flat_without_children_keys() -> None:
+    """Unassigned nodes carry no 'children' / 'has_children' keys - the block is a flat list"""
+    orphan_parent_range = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_BROAD)
+    orphan_child_range = _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=SUBNET_RANGE_NESTED)
+
+    with patch(
+        f'{PATH}.load_all_special_type_objects',
+        side_effect=[[], [orphan_parent_range, orphan_child_range]],
+    ):
+        tree = build_ipam_tree(MagicMock(), MagicMock())
+
+    assert len(tree[IpamTreeKey.UNASSIGNED]) == 2
+
+    for node in tree[IpamTreeKey.UNASSIGNED]:
+        assert IpamTreeKey.CHILDREN not in node
+        assert IpamTreeKey.HAS_CHILDREN not in node
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            build_supernet_subnet_tree                                                #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_build_supernet_subnet_tree_validates_then_nests_the_assigned_subnets() -> None:
+    """The supernet is validated first; the assigned subnets come back CIDR-nested"""
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+    broad = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_BROAD, name=SUBNET_NAME_A)
+    nested = _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=SUBNET_RANGE_NESTED, name=SUBNET_NAME_B)
+
+    with patch(f'{PATH}.load_supernet_object') as mock_validate, \
+         patch(f'{PATH}.load_subnets_for_supernet', return_value=[nested, broad]) as mock_load:
+        subtree = build_supernet_subnet_tree(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+
+    mock_validate.assert_called_once_with(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+    mock_load.assert_called_once_with(objects_manager, types_manager, SUPERNET_OBJECT_ID)
+
+    roots = subtree[IpamTreeKey.CHILDREN]
+    assert [n[CmdbObjectKey.PUBLIC_ID] for n in roots] == [SUBNET_OBJECT_ID_A]
+    assert [n[CmdbObjectKey.PUBLIC_ID] for n in roots[0][IpamTreeKey.CHILDREN]] == [SUBNET_OBJECT_ID_B]
+
+
+def test_build_supernet_subnet_tree_returns_empty_children_for_a_bare_supernet() -> None:
+    """A supernet without assigned subnets yields {'children': []} rather than erroring"""
+    with patch(f'{PATH}.load_supernet_object'), \
+         patch(f'{PATH}.load_subnets_for_supernet', return_value=[]):
+        subtree = build_supernet_subnet_tree(MagicMock(), MagicMock(), SUPERNET_OBJECT_ID)
+
+    assert subtree == {IpamTreeKey.CHILDREN: []}
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             build_unassigned_subnets                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_build_unassigned_subnets_filters_and_sorts_the_orphans() -> None:
+    """Only subnets without a usable ref are listed, in display order, under 'unassigned'"""
+    assigned = _make_subnet_doc(SUBNET_OBJECT_ID_A, network_range=SUBNET_RANGE_BROAD, supernet_ref=SUPERNET_OBJECT_ID)
+    orphan_high = _make_subnet_doc(SUBNET_OBJECT_ID_B, network_range=SUBNET_RANGE_SIBLING)
+    orphan_low = _make_subnet_doc(SUBNET_OBJECT_ID_C, network_range=SUBNET_RANGE_NESTED)
+
+    with patch(
+        f'{PATH}.load_all_special_type_objects',
+        return_value=[assigned, orphan_high, orphan_low],
+    ) as mock_load:
+        result = build_unassigned_subnets(MagicMock(), MagicMock())
+
+    assert mock_load.call_args.args[2] == SpecialType.SUBNET
+    assert [n[CmdbObjectKey.PUBLIC_ID] for n in result[IpamTreeKey.UNASSIGNED]] == [
+        SUBNET_OBJECT_ID_C, SUBNET_OBJECT_ID_B,
+    ]

--- a/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_subnet_routes.py
+++ b/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_subnet_routes.py
@@ -16,10 +16,12 @@
 """
 Unit tests for cmdb.interface.rest_api.routes.ipam_routes.ipam_subnet_routes
 
-Covers the route-glue of the three SUBNET routes: get_subnet_overview reads page / page_size /
+Covers the route-glue of the SUBNET routes: get_subnet_overview reads page / page_size /
 search / sort / order / status / type from the query string (applying the
 IpamSearch.MAX_QUERY_LENGTH truncation) and forwards them; get_invalid_subnet_overview forwards
-the page / search subset; unassign_ips_route forwards the body's 'ips' list and the request_user.
+the page / search subset; unassign_ips_route forwards the body's 'ips' list and the request_user;
+get_subnet_options forwards page / page_size / search / type and rejects invalid address-family
+tokens with 400 before the builder runs.
 Substantive behavior belongs to the framework-layer builders and is covered there; this module
 only exercises the transport boundary. The framework helpers and ManagerProvider.get_manager are
 patched at the route module path, and each route is unwrapped past its auth decorators.
@@ -30,12 +32,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from werkzeug.exceptions import HTTPException
 
-from cmdb.models.special_type_model.ipam_constants import IpamPagination, IpamSearch
+from cmdb.models.special_type_model.ipam_constants import IpAddressFamily, IpamPagination, IpamSearch
 from cmdb.interface.rest_api.routes.ipam_routes.ipam_subnet_routes import (
     get_subnet_overview,
+    get_subnet_options,
     get_invalid_subnet_overview,
+    get_subnet_sector_ips,
     unassign_ips_route,
+    export_subnet_ips,
 )
 # -------------------------------------------------------------------------------------------------------------------- #
 
@@ -142,6 +148,38 @@ def test_get_invalid_subnet_overview_truncates_search_at_max_query_length(flask_
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
+#                                             get_subnet_sector_ips                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_get_subnet_sector_ips_forwards_sector_start_and_pagination(flask_app: Flask) -> None:
+    """The sector route forwards public_id, sector_start and page/page_size to the builder"""
+    bare = _unwrap(get_subnet_sector_ips)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_sector_ips', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context('/overview/5/sector?sector_start=2001:db8::&page=2&page_size=10'):
+        bare(public_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
+
+    args, kwargs = mock_build.call_args
+    assert args[2] == SUBNET_PUBLIC_ID
+    assert args[3] == '2001:db8::'
+    assert kwargs == {'page': 2, 'page_size': 10}
+
+
+def test_get_subnet_sector_ips_aborts_400_when_sector_start_missing(flask_app: Flask) -> None:
+    """A request without sector_start aborts 400 before the builder runs"""
+    bare = _unwrap(get_subnet_sector_ips)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_sector_ips') as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context('/overview/5/sector'):
+        with pytest.raises(HTTPException) as exc_info:
+            bare(public_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
+
+    assert exc_info.value.code == 400
+    mock_build.assert_not_called()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
 #                                               unassign_ips_route                                                    #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_unassign_ips_route_forwards_public_id_ips_and_user(flask_app: Flask) -> None:
@@ -171,3 +209,122 @@ def test_unassign_ips_route_forwards_none_when_ips_key_absent(flask_app: Flask) 
         bare(public_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
 
     assert mock_unassign.call_args.args[3] is None
+
+
+def test_unassign_ips_route_forwards_mode_to_unassigner(flask_app: Flask) -> None:
+    """The body's 'mode' is forwarded as raw_mode; absent it forwards None (unassigner defaults it)"""
+    bare = _unwrap(unassign_ips_route)
+
+    with patch(f'{ROUTE_PATH}.unassign_ips_from_subnet', return_value={}) as mock_unassign, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context('/overview/5/unassign', method='POST',
+                                        json={'ips': ['10.0.0.1'], 'mode': 'row'}):
+        bare(public_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
+
+    assert mock_unassign.call_args.kwargs == {'raw_mode': 'row'}
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               export_subnet_ips                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_export_subnet_ips_returns_xlsx_attachment(flask_app: Flask) -> None:
+    """The route streams the builder's bytes as an xlsx attachment with a filename"""
+    bare = _unwrap(export_subnet_ips)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_ips_xlsx', return_value=b'xlsx-bytes') as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context('/overview/5/export'):
+        response = bare(public_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
+
+    assert mock_build.call_args.args[2] == SUBNET_PUBLIC_ID
+    assert response.get_data() == b'xlsx-bytes'
+    assert response.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    assert 'attachment; filename=subnet_5_ips_' in response.headers['Content-Disposition']
+
+
+def test_export_subnet_ips_propagates_too_big_abort(flask_app: Flask) -> None:
+    """A 400 raised by the builder (subnet too big) propagates out instead of becoming a 500"""
+    bare = _unwrap(export_subnet_ips)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_ips_xlsx', side_effect=HTTPException(), ), \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context('/overview/5/export'):
+        with pytest.raises(HTTPException):
+            bare(public_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               get_subnet_options                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+INVALID_FAMILY_TOKEN: str = 'ipv5'
+
+
+def test_get_subnet_options_forwards_all_query_params(flask_app: Flask) -> None:
+    """page / page_size / search / type are parsed and forwarded to the builder as keywords"""
+    bare = _unwrap(get_subnet_options)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_options_page', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/?page=3&page_size=20&search=db8&type={IpAddressFamily.IPV6.value}'):
+        bare(request_user=MagicMock())
+
+    _, kwargs = mock_build.call_args
+    assert kwargs == {
+        'page': 3, 'page_size': 20, 'search': 'db8', 'family': IpAddressFamily.IPV6.value,
+    }
+
+
+def test_get_subnet_options_applies_defaults_when_no_query_params(flask_app: Flask) -> None:
+    """Absent params fall back to page 1, the default page size, empty search and no family"""
+    bare = _unwrap(get_subnet_options)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_options_page', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context('/'):
+        bare(request_user=MagicMock())
+
+    _, kwargs = mock_build.call_args
+    assert kwargs == {
+        'page': 1, 'page_size': IpamPagination.DEFAULT_PAGE_SIZE, 'search': '', 'family': '',
+    }
+
+
+def test_get_subnet_options_truncates_search_at_max_query_length(flask_app: Flask) -> None:
+    """An over-long search is truncated to IpamSearch.MAX_QUERY_LENGTH at the route boundary"""
+    bare = _unwrap(get_subnet_options)
+    long_search: str = 'd' * (IpamSearch.MAX_QUERY_LENGTH + 15)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_options_page', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/?search={long_search}'):
+        bare(request_user=MagicMock())
+
+    _, kwargs = mock_build.call_args
+    assert kwargs['search'] == 'd' * IpamSearch.MAX_QUERY_LENGTH
+
+
+def test_get_subnet_options_aborts_400_on_invalid_family_token(flask_app: Flask) -> None:
+    """A 'type' value outside IpAddressFamily aborts 400 before the builder runs"""
+    bare = _unwrap(get_subnet_options)
+
+    with patch(f'{ROUTE_PATH}.build_subnet_options_page') as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/?type={INVALID_FAMILY_TOKEN}'):
+        with pytest.raises(HTTPException) as exc_info:
+            bare(request_user=MagicMock())
+
+    assert exc_info.value.code == 400
+    mock_build.assert_not_called()
+
+
+def test_get_subnet_options_accepts_both_valid_family_tokens(flask_app: Flask) -> None:
+    """Both IpAddressFamily values pass validation and reach the builder"""
+    bare = _unwrap(get_subnet_options)
+
+    for token in (IpAddressFamily.IPV4.value, IpAddressFamily.IPV6.value):
+        with patch(f'{ROUTE_PATH}.build_subnet_options_page', return_value={}) as mock_build, \
+             patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+             flask_app.test_request_context(f'/?type={token}'):
+            bare(request_user=MagicMock())
+
+        assert mock_build.call_args.kwargs['family'] == token

--- a/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_supernet_routes.py
+++ b/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_supernet_routes.py
@@ -16,12 +16,14 @@
 """
 Unit tests for cmdb.interface.rest_api.routes.ipam_routes.ipam_supernet_routes
 
-Covers the route-glue responsibilities of get_supernet_overview: reading page / page_size /
-search from the query string under their IpamOverviewKey constants, applying the
-IpamSearch.MAX_QUERY_LENGTH truncation cap, and forwarding the values to the framework-layer
-orchestrator. Substantive behavior (top-level vs. flat list, minimum query length, KPI
-computation) belongs to build_supernet_overview and is covered in the framework-layer tests;
-this module only exercises the transport boundary
+Covers the route-glue responsibilities of all five SUPERNET routes: get_supernet_overview and
+get_invalid_subnet_overview read page / page_size / search from the query string under their
+IpamOverviewKey constants and apply the IpamSearch.MAX_QUERY_LENGTH truncation cap;
+get_supernet_subnet_children forwards both path ids; unassign_subnets_route forwards the
+body's 'subnet_ids' list (None when absent); export_supernet_subnets streams the workbook as
+an attachment. Substantive behavior (top-level vs. flat list, minimum query length, KPI
+computation, containment, detach semantics) belongs to the framework-layer builders and is
+covered in the framework-layer tests; this module only exercises the transport boundary
 
 The route function carries auth decorators that abort outside a real session, so each test
 unwraps the decorator chain via __wrapped__ and calls the bare handler inside a Flask
@@ -35,22 +37,28 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 from openpyxl import load_workbook
+from werkzeug.exceptions import BadRequest, HTTPException
 
 from cmdb.models.special_type_model.ipam_constants import (
     IpamPagination,
     IpamSearch,
     IpamOverviewKey,
     IpamExport,
+    IpamUnassignKey,
     IpAddressFamily,
 )
 from cmdb.interface.rest_api.routes.ipam_routes.ipam_supernet_routes import (
     get_supernet_overview,
+    get_supernet_subnet_children,
+    get_invalid_subnet_overview,
+    unassign_subnets_route,
     export_supernet_subnets,
 )
 # -------------------------------------------------------------------------------------------------------------------- #
 
 ROUTE_PATH: str = 'cmdb.interface.rest_api.routes.ipam_routes.ipam_supernet_routes'
 SUPERNET_PUBLIC_ID: int = 42
+SUBNET_PUBLIC_ID: int = 7
 
 
 def _unwrap(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -250,3 +258,123 @@ def test_export_route_body_parses_as_a_valid_xlsx_workbook(
     # IPv4 supernet export keeps the trailing 'Usage (%)' column
     assert sheet_rows[0] == tuple(IpamExport.HEADERS + [IpamExport.USAGE_HEADER])
     assert sheet_rows[1] == ('10.0.0.0/24', '10.0.0.0 - 10.0.0.255', 3, 253, 1.17)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          get_supernet_subnet_children                                                #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_children_route_forwards_both_path_ids_to_the_builder(flask_app: Flask) -> None:
+    """The route passes the supernet and subnet public_ids (after the managers) to the builder"""
+    bare = _unwrap(get_supernet_subnet_children)
+
+    with patch(f'{ROUTE_PATH}.build_supernet_subnet_children', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/overview/{SUPERNET_PUBLIC_ID}/subnets/children/{SUBNET_PUBLIC_ID}'):
+        bare(public_id=SUPERNET_PUBLIC_ID, subnet_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
+
+    args = mock_build.call_args.args
+    assert args[2] == SUPERNET_PUBLIC_ID
+    assert args[3] == SUBNET_PUBLIC_ID
+
+
+def test_children_route_passes_builder_aborts_through(flask_app: Flask) -> None:
+    """An HTTPException from the builder (e.g. 400 for a foreign subnet) is re-raised, not wrapped"""
+    bare = _unwrap(get_supernet_subnet_children)
+
+    with patch(f'{ROUTE_PATH}.build_supernet_subnet_children', side_effect=BadRequest('foreign')), \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/overview/{SUPERNET_PUBLIC_ID}/subnets/children/{SUBNET_PUBLIC_ID}'):
+        with pytest.raises(HTTPException) as exc_info:
+            bare(public_id=SUPERNET_PUBLIC_ID, subnet_id=SUBNET_PUBLIC_ID, request_user=MagicMock())
+
+    assert exc_info.value.code == 400
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                           get_invalid_subnet_overview                                                #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_invalid_route_forwards_page_page_size_and_search(flask_app: Flask) -> None:
+    """The invalid-only route forwards public_id plus the page / page_size / search subset"""
+    bare = _unwrap(get_invalid_subnet_overview)
+
+    with patch(f'{ROUTE_PATH}.build_invalid_subnet_overview', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(
+             f'/overview/{SUPERNET_PUBLIC_ID}/subnets/invalid?page=2&page_size=25&search=10.0'):
+        bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    args, kwargs = mock_build.call_args
+    assert args[2] == SUPERNET_PUBLIC_ID
+    assert kwargs == {'page': 2, 'page_size': 25, 'search': '10.0'}
+
+
+def test_invalid_route_applies_defaults_when_no_query_params(flask_app: Flask) -> None:
+    """Absent params fall back to page 1, the default page size and an empty search"""
+    bare = _unwrap(get_invalid_subnet_overview)
+
+    with patch(f'{ROUTE_PATH}.build_invalid_subnet_overview', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/overview/{SUPERNET_PUBLIC_ID}/subnets/invalid'):
+        bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    _, kwargs = mock_build.call_args
+    assert kwargs == {'page': 1, 'page_size': IpamPagination.DEFAULT_PAGE_SIZE, 'search': ''}
+
+
+def test_invalid_route_truncates_search_at_max_query_length(flask_app: Flask) -> None:
+    """The invalid-only route applies the same search-length cap as the main overview"""
+    bare = _unwrap(get_invalid_subnet_overview)
+    long_search: str = 'c' * (IpamSearch.MAX_QUERY_LENGTH + 10)
+
+    with patch(f'{ROUTE_PATH}.build_invalid_subnet_overview', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/overview/{SUPERNET_PUBLIC_ID}/subnets/invalid?search={long_search}'):
+        bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    _, kwargs = mock_build.call_args
+    assert kwargs['search'] == 'c' * IpamSearch.MAX_QUERY_LENGTH
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             unassign_subnets_route                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_unassign_route_forwards_public_id_and_subnet_ids(flask_app: Flask) -> None:
+    """The route forwards the supernet public_id and the body's 'subnet_ids' list verbatim"""
+    bare = _unwrap(unassign_subnets_route)
+    subnet_ids: list[int] = [SUBNET_PUBLIC_ID, SUBNET_PUBLIC_ID + 1]
+
+    with patch(f'{ROUTE_PATH}.unassign_subnets_from_supernet', return_value={}) as mock_unassign, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/overview/{SUPERNET_PUBLIC_ID}/subnets/unassign', method='POST',
+                                        json={IpamUnassignKey.SUBNET_IDS: subnet_ids}):
+        bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    args = mock_unassign.call_args.args
+    assert args[2] == SUPERNET_PUBLIC_ID
+    assert args[3] == subnet_ids
+
+
+def test_unassign_route_forwards_none_when_subnet_ids_key_absent(flask_app: Flask) -> None:
+    """A body without 'subnet_ids' (or no JSON body at all) forwards None so the detacher emits its own 400"""
+    bare = _unwrap(unassign_subnets_route)
+
+    with patch(f'{ROUTE_PATH}.unassign_subnets_from_supernet', return_value={}) as mock_unassign, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/overview/{SUPERNET_PUBLIC_ID}/subnets/unassign', method='POST', json={}):
+        bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    assert mock_unassign.call_args.args[3] is None
+
+
+def test_unassign_route_passes_builder_aborts_through(flask_app: Flask) -> None:
+    """An HTTPException from the detacher (e.g. 400 for foreign ids) is re-raised, not wrapped"""
+    bare = _unwrap(unassign_subnets_route)
+
+    with patch(f'{ROUTE_PATH}.unassign_subnets_from_supernet', side_effect=BadRequest('foreign')), \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/overview/{SUPERNET_PUBLIC_ID}/subnets/unassign', method='POST',
+                                        json={IpamUnassignKey.SUBNET_IDS: [SUBNET_PUBLIC_ID]}):
+        with pytest.raises(HTTPException) as exc_info:
+            bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    assert exc_info.value.code == 400

--- a/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_tree_routes.py
+++ b/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_tree_routes.py
@@ -1,0 +1,136 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for cmdb.interface.rest_api.routes.ipam_routes.ipam_tree_routes
+
+Covers the route-glue of the three sidebar-tree routes: each resolves the objects / types
+managers via ManagerProvider, forwards them (plus the supernet public_id where applicable) to
+its framework builder and wraps the builder's payload in a DefaultResponse. HTTPExceptions
+raised below the route (e.g. the 400/404 aborts of the supernet loader) pass through
+unwrapped, while unexpected errors convert to a 500. Substantive behavior belongs to the
+framework-layer builders and is covered there; this module only exercises the transport
+boundary. The builders and ManagerProvider.get_manager are patched at the route module path,
+and each route is unwrapped past its auth decorators
+"""
+from typing import Any, Callable
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+from werkzeug.exceptions import HTTPException, NotFound
+
+from cmdb.interface.rest_api.routes.ipam_routes.ipam_tree_routes import (
+    get_ipam_tree,
+    get_supernet_subnet_tree,
+    get_unassigned_subnets,
+)
+# -------------------------------------------------------------------------------------------------------------------- #
+
+ROUTE_PATH: str = 'cmdb.interface.rest_api.routes.ipam_routes.ipam_tree_routes'
+SUPERNET_PUBLIC_ID: int = 7
+
+
+def _unwrap(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Strips the @verify_api_access / @insert_request_user decorators off a route function."""
+    inner = func
+
+    while hasattr(inner, '__wrapped__'):
+        inner = inner.__wrapped__
+
+    return inner
+
+
+@pytest.fixture(name='flask_app')
+def fixture_flask_app() -> Flask:
+    """Returns a minimal Flask app to host the test_request_context calls."""
+    return Flask(__name__)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                  get_ipam_tree                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_get_ipam_tree_forwards_the_managers_to_the_builder(flask_app: Flask) -> None:
+    """The route resolves both managers and passes them to build_ipam_tree"""
+    bare = _unwrap(get_ipam_tree)
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+
+    with patch(f'{ROUTE_PATH}.build_ipam_tree', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', side_effect=[objects_manager, types_manager]), \
+         flask_app.test_request_context('/'):
+        bare(request_user=MagicMock())
+
+    mock_build.assert_called_once_with(objects_manager, types_manager)
+
+
+def test_get_ipam_tree_converts_unexpected_errors_to_500(flask_app: Flask) -> None:
+    """A non-HTTP exception from the builder aborts with HTTP 500"""
+    bare = _unwrap(get_ipam_tree)
+
+    with patch(f'{ROUTE_PATH}.build_ipam_tree', side_effect=RuntimeError('boom')), \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context('/'):
+        with pytest.raises(HTTPException) as exc_info:
+            bare(request_user=MagicMock())
+
+    assert exc_info.value.code == 500
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                            get_supernet_subnet_tree                                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_get_supernet_subnet_tree_forwards_managers_and_public_id(flask_app: Flask) -> None:
+    """The route passes both managers and the supernet public_id to the subtree builder"""
+    bare = _unwrap(get_supernet_subnet_tree)
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+
+    with patch(f'{ROUTE_PATH}.build_supernet_subnet_tree', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', side_effect=[objects_manager, types_manager]), \
+         flask_app.test_request_context(f'/supernets/{SUPERNET_PUBLIC_ID}'):
+        bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    mock_build.assert_called_once_with(objects_manager, types_manager, SUPERNET_PUBLIC_ID)
+
+
+def test_get_supernet_subnet_tree_passes_http_exceptions_through(flask_app: Flask) -> None:
+    """A builder abort (e.g. 404 from the supernet loader) is re-raised, not wrapped into a 500"""
+    bare = _unwrap(get_supernet_subnet_tree)
+
+    with patch(f'{ROUTE_PATH}.build_supernet_subnet_tree', side_effect=NotFound('missing')), \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', return_value=MagicMock()), \
+         flask_app.test_request_context(f'/supernets/{SUPERNET_PUBLIC_ID}'):
+        with pytest.raises(HTTPException) as exc_info:
+            bare(public_id=SUPERNET_PUBLIC_ID, request_user=MagicMock())
+
+    assert exc_info.value.code == 404
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             get_unassigned_subnets                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_get_unassigned_subnets_forwards_the_managers_to_the_builder(flask_app: Flask) -> None:
+    """The route resolves both managers and passes them to build_unassigned_subnets"""
+    bare = _unwrap(get_unassigned_subnets)
+    objects_manager = MagicMock()
+    types_manager = MagicMock()
+
+    with patch(f'{ROUTE_PATH}.build_unassigned_subnets', return_value={}) as mock_build, \
+         patch(f'{ROUTE_PATH}.ManagerProvider.get_manager', side_effect=[objects_manager, types_manager]), \
+         flask_app.test_request_context('/unassigned'):
+        bare(request_user=MagicMock())
+
+    mock_build.assert_called_once_with(objects_manager, types_manager)

--- a/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_validation_routes.py
+++ b/tests/unit/interface/rest_api/routes/ipam_routes/test_ipam_validation_routes.py
@@ -99,13 +99,23 @@ def test_build_validation_response_invalid_for_non_empty_errors() -> None:
 #                                          _parse_interface_rows_payload                                               #
 # -------------------------------------------------------------------------------------------------------------------- #
 def test_parse_interface_rows_payload_maps_rows_to_tuples() -> None:
-    """Each row dict maps to (row_index, subnet_ref, ip); missing optional fields become None"""
+    """Each row dict maps to (row_index, subnet_ref, ip, interface_type); missing fields become None"""
     rows = _parse_interface_rows_payload([
         {'row_index': 0, 'subnet_id': 200, 'ip_address': '2001:db8::5'},
         {'row_index': 1},
     ])
 
-    assert rows == [(0, 200, '2001:db8::5'), (1, None, None)]
+    assert rows == [(0, 200, '2001:db8::5', None), (1, None, None, None)]
+
+
+def test_parse_interface_rows_payload_passes_interface_type_through() -> None:
+    """A non-empty 'interface_type' lands in the fourth tuple slot; an empty one becomes None"""
+    rows = _parse_interface_rows_payload([
+        {'row_index': 0, 'subnet_id': 200, 'ip_address': '2001:db8::5', 'interface_type': 'ipv6'},
+        {'row_index': 1, 'interface_type': ''},
+    ])
+
+    assert rows == [(0, 200, '2001:db8::5', 'ipv6'), (1, None, None, None)]
 
 
 def test_parse_interface_rows_payload_aborts_for_non_dict_entry() -> None:
@@ -261,7 +271,7 @@ def test_validate_interface_route_forwards_parsed_rows_and_exclude(flask_app: Fl
         bare(request_user=MagicMock())
 
     args, kwargs = mock_validate.call_args
-    assert args[2] == [(0, 200, '2001:db8::5')]
+    assert args[2] == [(0, 200, '2001:db8::5', None)]
     assert kwargs == {'exclude_object_id': 300}
 
 

--- a/tests/unit/models/special_type_model/test_special_type_enum.py
+++ b/tests/unit/models/special_type_model/test_special_type_enum.py
@@ -1,0 +1,68 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2026 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for cmdb.models.special_type_model.special_type_enum
+
+Pins the member tokens and display labels of the SpecialType enum (both are wire-format
+values the frontend depends on) and covers the get_unused_types filter that drives the
+special-type creation dialog
+"""
+from cmdb.models.special_type_model.special_type_enum import SpecialType
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               get_special_types                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_get_special_types_maps_every_member_to_its_display_label() -> None:
+    """The full listing pins every member token and its fixed English display label"""
+    assert SpecialType.get_special_types() == {
+        SpecialType.SUPERNET: 'IPAM - Supernet class',
+        SpecialType.SUBNET: 'IPAM - Subnet class',
+        SpecialType.VLAN: 'IPAM - VLAN class',
+    }
+
+
+def test_get_special_types_covers_every_enum_member() -> None:
+    """Adding a SpecialType member without a display label fails loudly here"""
+    assert set(SpecialType.get_special_types()) == set(SpecialType)
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                get_unused_types                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_get_unused_types_omits_claimed_special_types() -> None:
+    """A SpecialType value present in 'existing' drops out of the offer"""
+    unused = SpecialType.get_unused_types([SpecialType.SUBNET.value])
+
+    assert set(unused) == {SpecialType.SUPERNET, SpecialType.VLAN}
+
+
+def test_get_unused_types_returns_everything_when_nothing_exists() -> None:
+    """An empty 'existing' iterable leaves the full listing intact"""
+    assert SpecialType.get_unused_types([]) == SpecialType.get_special_types()
+
+
+def test_get_unused_types_returns_empty_when_all_claimed() -> None:
+    """With every member claimed, nothing is offered"""
+    assert SpecialType.get_unused_types([m.value for m in SpecialType]) == {}
+
+
+def test_get_unused_types_ignores_unknown_tokens() -> None:
+    """Tokens in 'existing' that are no SpecialType value have no effect on the offer"""
+    unused = SpecialType.get_unused_types(['NOT-A-SPECIAL-TYPE'])
+
+    assert unused == SpecialType.get_special_types()


### PR DESCRIPTION
Changes:
* added routes for ipam tree in sidebar
* added route to unassign multiple interface rows or delete them
* filter for subnet-overview for per cell filtering
* export of subnet-overview implemented