### PR TITLE
DAT-2796-lock-external-api

### DIFF
--- a/cmdb/interface/rest_api/init_rest_api.py
+++ b/cmdb/interface/rest_api/init_rest_api.py
@@ -90,6 +90,11 @@ def create_rest_api(database_maanger: MongoDatabaseManager) -> BaseCmdbApp:
     # Import App Extensions
     CORS(app=app, expose_headers=['X-API-Version', 'X-Total-Count'])
 
+    # Lock the external REST API (HTTP Basic auth) behind the REST_API license feature. On-premise
+    # only; a no-op in cloud/local mode. The UI (login + Bearer JWT) is unaffected.
+    from cmdb.interface.rest_api.routes.cmdb_license.license_guard import enforce_rest_api_license
+    app.before_request(enforce_rest_api_license)
+
     if cmdb.__MODE__ == 'DEBUG':
         config = app_config['development']
         app.config.from_object(config)

--- a/cmdb/interface/rest_api/routes/cmdb_license/license_guard.py
+++ b/cmdb/interface/rest_api/routes/cmdb_license/license_guard.py
@@ -36,6 +36,7 @@ from cmdb.manager.license_manager.license_service import LicenseService
 
 from cmdb.models.user_model import CmdbUser
 
+from cmdb.interface.rest_api.auth_method_enum import AuthMethod
 from cmdb.security.license.license_constants import LicenseFeature
 # -------------------------------------------------------------------------------------------------------------------- #
 
@@ -43,6 +44,9 @@ LOGGER: Logger = getLogger(__name__)
 
 # `flask.g` attribute under which the per-request {LicenseFeature: bool} lookup cache is stored
 LICENSE_FEATURE_CACHE_ATTR: str = 'license_feature_cache'
+
+# Prefix of an `Authorization` header carrying HTTP Basic credentials (e.g. "Basic dXNlcjpwYXNz")
+BASIC_AUTH_HEADER_PREFIX: str = f'{AuthMethod.BASIC.value} '
 
 # 403 body when a feature is not unlocked; `{feature}` is filled with a human-readable feature label
 FEATURE_NOT_LICENSED_MESSAGE: str = "The {feature} feature requires a valid license!"
@@ -191,3 +195,32 @@ def gate_blueprint(blueprint: Blueprint, feature: LicenseFeature) -> None:
         abort_if_feature_locked(feature)
 
     blueprint.before_request(enforce_feature)
+
+
+def enforce_rest_api_license() -> None:
+    """
+    Blocks HTTP Basic-auth REST calls when the REST_API feature is not licensed (on-premise only)
+
+    Registered as an app-level `before_request` on the REST API. On-premise the two auth channels are
+    distinguishable: external automation authenticates per request with `Authorization: Basic
+    <user:pass>` (`parse_authorization_header` mints a token from those credentials on every call),
+    whereas the Angular UI logs in once via `POST /auth/login` (a JSON body, no `Authorization`
+    header) and then sends `Authorization: Bearer <jwt>`. Refusing Basic-auth requests therefore
+    locks the external REST API while leaving the UI - login and every Bearer call - fully
+    functional. The determined caller can still script the login+Bearer flow; this is a deliberate,
+    accepted gap (the mint route stays open so users can always log in).
+
+    CORS preflight `OPTIONS` is never gated. In cloud or local mode the check is a no-op
+    (`abort_if_feature_locked` returns without effect there), leaving the cloud `x-api-key` +
+    api-level gating untouched.
+    """
+    # Never gate the CORS preflight (see gate_blueprint for the rationale)
+    if request.method == 'OPTIONS':
+        return
+
+    auth_header: str | None = request.headers.get('Authorization')
+
+    # Case-insensitive match: parse_authorization_header lowercases the scheme before accepting it,
+    # so a lowercase "basic " header still authenticates and must be gated the same way
+    if auth_header and auth_header.lower().startswith(BASIC_AUTH_HEADER_PREFIX.lower()):
+        abort_if_feature_locked(LicenseFeature.REST_API)

--- a/cmdb/interface/rest_api/routes/framework_routes/cmdb_objects/objects_helper.py
+++ b/cmdb/interface/rest_api/routes/framework_routes/cmdb_objects/objects_helper.py
@@ -16,14 +16,17 @@
 """
 Helper methods for CmdbObject routes
 """
+import copy
 import json
+from datetime import datetime, timezone
 from logging import Logger, getLogger
 from typing import Any
 
+from bson import json_util
 from flask import abort, current_app
 from werkzeug.exceptions import HTTPException
 
-from cmdb.database.database_utils import default
+from cmdb.database.database_utils import default, object_hook
 from cmdb.framework.rendering.render_result import RenderResult
 from cmdb.framework.rendering.render_list import RenderList
 from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
@@ -53,7 +56,10 @@ from cmdb.framework.rendering.cmdb_multi_render import CmdbMultiRender
 from cmdb.framework.ipam.enforcement import (
     object_write_requires_ipam_license,
     object_delete_requires_ipam_license,
+    enforce_object_invariants,
+    format_errors_for_abort,
 )
+from cmdb.security.acl.permission import AccessControlPermission
 from cmdb.interface.rest_api.routes.cmdb_license.license_guard import abort_if_feature_locked
 from cmdb.interface.rest_api.routes.framework_routes.cmdb_objects.objects_constants import ObjectViewMode
 from cmdb.security.license.license_constants import LicenseFeature
@@ -353,7 +359,7 @@ def handle_delete_object_location(request_user: CmdbUser, public_id: int) -> Non
         public_id (int): public_id of the CmdbObject whose location should be removed
 
     Raises:
-        HTTPException: 405 when the object's location is a parent of other locations, or 500 on an
+        HTTPException: 400 when the object's location is a parent of other locations, or 500 on an
             unexpected error
     """
     try:
@@ -365,7 +371,7 @@ def handle_delete_object_location(request_user: CmdbUser, public_id: int) -> Non
             child_location = locations_manager.get_one_by({'parent': object_location['public_id']})
 
             if child_location and len(child_location) > 0:
-                abort(405, "The Location of this Object has child Locations and is therefore not deletable!")
+                abort(400, "The Location of this Object has child Locations and is therefore not deletable!")
 
             # Delete the location because it is not a parent to another location
             locations_manager.delete_location(object_location['public_id'])
@@ -542,3 +548,265 @@ def validate_and_fill_object_fields(objects_manager: ObjectsManager, object_data
     for section in object_data.get("multi_data_sections", []):
         for value in section.get("values", []):
             validate_field_list(value.get("data", []))
+
+
+def to_normalized_cmdb_object(object_data: dict[str, Any]) -> CmdbObject:
+    """
+    Builds a CmdbObject from a payload dict, normalizing BSON types via a JSON round-trip
+
+    The round-trip (``json.dumps(..., default=default)`` then ``json.loads(..., object_hook)``)
+    coerces Python/BSON values (e.g. datetimes) into the canonical shape the model expects,
+    matching how the object is stored and compared
+
+    Args:
+        object_data (dict[str, Any]): The object payload to convert
+
+    Returns:
+        CmdbObject: The constructed CmdbObject instance
+    """
+    return CmdbObject(**json.loads(json.dumps(object_data, default=default), object_hook=object_hook))
+
+
+def build_new_object_data(
+        objects_manager: ObjectsManager,
+        request_data: dict[str, Any],
+    ) -> tuple[dict[str, Any], CmdbType]:
+    """
+    Normalises a raw insert payload into a ready-to-store CmdbObject document
+
+    Applies the BSON object_hook, assigns a fresh public_id (or verifies a supplied one is unused),
+    resolves and returns the target CmdbType, defaults the active flag, stamps creation_time and the
+    initial version, and validates/backfills the field types
+
+    Args:
+        objects_manager (ObjectsManager): Manager used to resolve ids/types and check existence
+        request_data (dict[str, Any]): The raw request body of the new CmdbObject
+
+    Returns:
+        tuple[dict[str, Any], CmdbType]: The prepared object document and its resolved CmdbType
+
+    Raises:
+        HTTPException: 400 when the supplied public_id already exists, 404 when the type is unknown,
+            or the 400s raised by validate_and_fill_object_fields
+    """
+    new_object_data: dict[str, Any] = json.loads(json.dumps(request_data), object_hook=json_util.object_hook)
+
+    if "public_id" not in new_object_data:
+        new_object_data['public_id'] = objects_manager.get_new_object_public_id()
+    else:
+        existing_object: dict[str, Any] | None = objects_manager.get_object(new_object_data['public_id'])
+
+        if existing_object:
+            abort(400, f'Object with ID: {new_object_data["public_id"]} already exists!')
+
+    object_type: CmdbType | None = objects_manager.get_object_type(new_object_data['type_id'])
+
+    if not object_type:
+        abort(404, f"Type with ID:{new_object_data['type_id']} of new Object not found!")
+
+    if 'active' not in new_object_data:
+        new_object_data['active'] = True
+
+    new_object_data['creation_time'] = datetime.now(timezone.utc)
+    new_object_data['version'] = '1.0.0'
+
+    # Validate fields have a type property (and backfill it from the type schema when omitted)
+    validate_and_fill_object_fields(objects_manager, new_object_data)
+
+    return new_object_data, object_type
+
+
+def compute_object_version(current_object: CmdbObject, updated_object: CmdbObject) -> tuple[str, dict[str, Any]]:
+    """
+    Derives the field-level diff and applies the resulting semantic version bump
+
+    The bump is chosen from how many fields changed relative to the total field count: a single
+    changed field is a PATCH, all fields a MAJOR, more than half a MINOR, and anything else a PATCH.
+    ``updated_object`` is mutated in place with the new version
+
+    Args:
+        current_object (CmdbObject): The stored object before the update
+        updated_object (CmdbObject): The candidate object after the update
+
+    Returns:
+        tuple[str, dict[str, Any]]: The new version string and the diff (as returned by ``/``)
+    """
+    changes: dict[str, Any] = current_object / updated_object
+
+    changed_count: int = len(changes['new'])
+    field_count: int = len(updated_object.fields)
+
+    if changed_count == 1:
+        version_type = updated_object.VERSIONING_PATCH
+    elif changed_count == field_count:
+        version_type = updated_object.VERSIONING_MAJOR
+    elif changed_count > (field_count / 2):
+        version_type = updated_object.VERSIONING_MINOR
+    else:
+        version_type = updated_object.VERSIONING_PATCH
+
+    return updated_object.update_version(version_type), changes
+
+
+def emit_object_update_events(
+        request_user: CmdbUser,
+        logs_manager: LogsManager,
+        before_object: CmdbObject,
+        after_object: CmdbObject,
+        updated_object: CmdbObject,
+        changes: dict[str, Any],
+        update_comment: str,
+    ) -> None:
+    """
+    Emits the UPDATE webhook and writes the edit log for an updated CmdbObject
+
+    Both steps are best-effort and isolated: a webhook or logging failure is caught and logged so it
+    never blocks the object update
+
+    Args:
+        request_user (CmdbUser): The CmdbUser making the request
+        logs_manager (LogsManager): Manager used to persist the edit log
+        before_object (CmdbObject): The object state before the update (webhook payload)
+        after_object (CmdbObject): The re-read object state after the update (webhook payload)
+        updated_object (CmdbObject): The candidate object carrying the bumped version / render_state
+        changes (dict[str, Any]): The field-level diff recorded on the webhook and log
+        update_comment (str): The user-supplied comment stored on the edit log
+    """
+    try:
+        send_webhook_event(request_user,
+                           WebhookEventType.UPDATE,
+                           CmdbObject.to_json(before_object),
+                           CmdbObject.to_json(after_object),
+                           changes)
+    except Exception as error:
+        LOGGER.error("[emit_object_update_events] Send Webhook Event Exception: %s, Type:%s", error, type(error))
+
+    try:
+        log_data: dict[str, Any] = {
+            'object_id': after_object.get_public_id(),
+            'version': updated_object.get_version(),
+            'user_id': request_user.get_public_id(),
+            'user_name': request_user.get_display_name(),
+            'comment': update_comment,
+            'changes': changes,
+            'render_state': json.dumps(updated_object, default=default).encode('UTF-8'),
+        }
+        logs_manager.insert_log(action=LogAction.EDIT, log_type=CmdbObjectLog.__name__, **log_data)
+    except Exception as error:
+        LOGGER.error("[emit_object_update_events] Failed to create Log. Error: %s", error)
+
+
+# Cohesive single-object update orchestration (fetch -> guard -> validate -> persist -> side effects);
+# the local count is inherent to the sequence, so the too-many-locals check is scoped off here
+def apply_object_update(  # pylint: disable=too-many-locals
+        obj_id: int,
+        payload: dict[str, Any],
+        active_state: bool | None,
+        request_user: CmdbUser,
+        objects_manager: ObjectsManager,
+        types_manager: TypesManager,
+        logs_manager: LogsManager,
+    ) -> dict[str, Any]:
+    """
+    Applies a full-object update to a single CmdbObject and runs its side effects
+
+    DataGerry has no partial-update semantics: the complete object is always sent, so the payload
+    fields are authoritative. Refuses a special_type change, enforces the IPAM license + invariants,
+    computes the version bump, persists the object, syncs new select options and emits the update
+    webhook + edit log
+
+    Args:
+        obj_id (int): public_id of the CmdbObject to update
+        payload (dict[str, Any]): The validated full-object payload (shared across bulk targets)
+        active_state (bool | None): The active flag to apply, or None to keep the object's current
+        request_user (CmdbUser): The CmdbUser making the request
+        objects_manager (ObjectsManager): db interface for CmdbObjects
+        types_manager (TypesManager): db interface for CmdbTypes (IPAM license/invariant checks)
+        logs_manager (LogsManager): Manager used to persist the edit log
+
+    Returns:
+        dict[str, Any]: The persisted object document (one entry of the update response)
+
+    Raises:
+        HTTPException: 404 when the object is missing before/after the write, 400 on a special_type
+            change or an IPAM invariant violation, 500 when the object's type cannot be resolved
+    """
+    new_data: dict[str, Any] = copy.deepcopy(payload)
+
+    current_object_instance: CmdbObject | None = objects_manager.get_object(
+        obj_id,
+        request_user,
+        AccessControlPermission.READ,
+        as_dict=False,
+    )
+
+    if not current_object_instance:
+        abort(404, f"Object with ID:{obj_id} not found!")
+
+    if is_special_type_changed(current_object_instance.special_type, new_data.get('special_type')):
+        abort(400, f"SpecialType of an Object is not changable. Occured for Object with ID: {obj_id}")
+
+    current_type_instance: CmdbType | None = objects_manager.get_object_type(current_object_instance.get_type_id())
+
+    if not current_type_instance:
+        abort(500, "Type of Object not found in database!")
+
+    new_data.update({
+        'public_id': obj_id,
+        'creation_time': current_object_instance.creation_time,
+        'author_id': current_object_instance.author_id,
+        'active': active_state if active_state in [True, False] else current_object_instance.active,
+        'version': payload.get('version', current_object_instance.version),
+        'last_edit_time': datetime.now(timezone.utc),
+        'editor_id': request_user.public_id,
+    })
+
+    update_comment: str = new_data.pop('comment', "")
+
+    # Validate fields have a type (and backfill it) - the full payload is the source of truth
+    validate_and_fill_object_fields(objects_manager, new_data)
+
+    previous_object: dict[str, Any] = CmdbObject.to_json(current_object_instance)
+
+    # Editing an IPAM special-type object (or adding/changing an interface subnet) needs an IPAM license
+    guard_object_write_license(types_manager, request_user, new_data, previous_object)
+
+    ipam_errors: list[dict[str, Any]] = enforce_object_invariants(
+        objects_manager,
+        types_manager,
+        new_data,
+        previous_object=previous_object,
+    )
+
+    if ipam_errors:
+        abort(400, format_errors_for_abort(ipam_errors))
+
+    update_object_instance: CmdbObject = to_normalized_cmdb_object(new_data)
+
+    new_version, changes = compute_object_version(current_object_instance, update_object_instance)
+    new_data['version'] = new_version
+
+    objects_manager.update_object(obj_id, new_data, request_user, AccessControlPermission.UPDATE)
+
+    object_after: dict[str, Any] | None = objects_manager.get_object(obj_id, request_user, AccessControlPermission.READ)
+
+    if not object_after:
+        abort(404, f"Updated Object with ID:{obj_id} not found in database!")
+
+    object_after: CmdbObject = CmdbObject.from_data(object_after)
+
+    # sync select fields
+    if object_after.has_fields_of_type(FieldType.SELECT):
+        sync_select_field_options(request_user, object_after, current_type_instance)
+
+    emit_object_update_events(
+        request_user,
+        logs_manager,
+        current_object_instance,
+        object_after,
+        update_object_instance,
+        changes,
+        update_comment,
+    )
+
+    return new_data

--- a/cmdb/interface/rest_api/routes/framework_routes/cmdb_objects/objects_routes.py
+++ b/cmdb/interface/rest_api/routes/framework_routes/cmdb_objects/objects_routes.py
@@ -17,17 +17,14 @@
 Implementation of all API routes for CmdbObjects
 """
 import json
-import copy
 from logging import Logger, getLogger
 from typing import Any
-from datetime import datetime, timezone
-from bson import json_util
 from pymongo import UpdateOne
 from flask import abort, current_app, request
 from werkzeug import Response
 from werkzeug.exceptions import HTTPException
 
-from cmdb.database.database_utils import default, object_hook
+from cmdb.database.database_utils import default
 from cmdb.manager.manager_provider_model import ManagerProvider, ManagerType
 from cmdb.manager.query_builder import BuilderParameters
 from cmdb.manager import (
@@ -67,10 +64,10 @@ from cmdb.interface.rest_api.routes.framework_routes.cmdb_objects.objects_helper
     handle_delete_from_object_groups,
     handle_delete_object_location,
     handle_delete_location_and_child_locations,
-    validate_and_fill_object_fields,
     sync_select_field_options,
-    is_special_type_changed,
     render_or_native,
+    build_new_object_data,
+    apply_object_update,
     guard_object_write_license,
     guard_object_delete_license,
 )
@@ -98,6 +95,7 @@ from cmdb.errors.manager.objects_manager import (
     ObjectsManagerInsertError,
     ObjectsManagerIterationError,
 )
+from cmdb.errors.manager.types_manager import TypesManagerGetError
 from cmdb.errors.security import AccessDeniedError
 # -------------------------------------------------------------------------------------------------------------------- #
 
@@ -110,7 +108,6 @@ MAX_DASHBOARD_GROUPS: int = 5
 
 # --------------------------------------------------- CRUD - CREATE -------------------------------------------------- #
 
-#TODO: REFACTOR-FIX (reduce complexity)
 @objects_blueprint.route('/', methods=['POST'])
 @handle_db_errors
 @insert_request_user
@@ -131,42 +128,18 @@ def insert_cmdb_object(request_user: CmdbUser) -> Response:
         DefaultResponse: The public_id of the newly inserted CmdbObject
     """
     try:
-        #TODO: REFACTOR-FIX (pass the data same way as on other routes and add schema validation)
-        new_object_json = json.dumps(request.json)
-
         objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
         types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
 
         objects_count: int = 0
 
         if current_app.cloud_mode:
-            objects_count: int = objects_manager.count_documents()
+            objects_count = objects_manager.count_documents()
             if request_user.is_config_item_limit_reached(objects_count):
                 abort(400, "The maximum amout of ConfigItems is reached!")
 
-        new_object_data = json.loads(new_object_json, object_hook=json_util.object_hook)
-
-        if "public_id" not in new_object_data:
-            new_object_data['public_id'] = objects_manager.get_new_object_public_id()
-        else:
-            existing_object: dict[str, Any] | None = objects_manager.get_object(new_object_data['public_id'])
-
-            if existing_object:
-                abort(400, f'Object with ID: {new_object_data["public_id"]} already exists!')
-
-        object_type: CmdbType | None = objects_manager.get_object_type(new_object_data['type_id'])
-
-        if not object_type:
-            abort(404, f"Type with ID:{new_object_data['type_id']} of new Object not found!")
-
-        if 'active' not in new_object_data:
-            new_object_data['active'] = True
-
-        new_object_data['creation_time'] = datetime.now(timezone.utc)
-        new_object_data['version'] = '1.0.0'
-
-        # Validate fields have type property
-        validate_and_fill_object_fields(objects_manager, new_object_data)
+        # Normalise the payload: assign/verify public_id, resolve the type, stamp defaults + version
+        new_object_data, object_type = build_new_object_data(objects_manager, request.json)
 
         # Creating an IPAM special-type object (or linking a subnet on an interface) needs an IPAM license
         guard_object_write_license(types_manager, request_user, new_object_data)
@@ -456,17 +429,25 @@ def group_cmdb_objects_by_type_id(value: str, request_user: CmdbUser) -> Respons
     """
     try:
         objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
 
         filter_state = {'active': {'$eq': True}} if fetch_only_active_objects() else None
 
         result = []
-        cursor = objects_manager.group_objects_by_value(value,
-                                                        filter_state,
-                                                        request_user,
-                                                        AccessControlPermission.READ)
+        grouped_documents: list[dict[str, Any]] = list(objects_manager.group_objects_by_value(
+            value,
+            filter_state,
+            request_user,
+            AccessControlPermission.READ,
+        ))
 
-        for document in cursor:
-            cur_type = objects_manager.get_object_type(document['_id'])
+        # Resolve every group's Type in a single lookup instead of one query per group (N+1)
+        type_map: dict[int, CmdbType] = types_manager.get_types_lookup(
+            [document['_id'] for document in grouped_documents]
+        )
+
+        for document in grouped_documents:
+            cur_type: CmdbType | None = type_map.get(document['_id'])
 
             # Skip groups whose Type no longer exists (e.g. orphaned objects of a deleted Type)
             if not cur_type:
@@ -480,6 +461,9 @@ def group_cmdb_objects_by_type_id(value: str, request_user: CmdbUser) -> Respons
                 break
 
         return DefaultResponse(result).make_response()
+    except TypesManagerGetError as err:
+        LOGGER.error("[group_cmdb_objects_by_type_id] TypesManagerGetError: %s", err, exc_info=True)
+        abort(400, "Failed to retrieve the Type of an Object from the database!")
     except ObjectsManagerGetError as err:
         LOGGER.error("[group_cmdb_objects_by_type_id] ObjectsManagerGetError: %s", err, exc_info=True)
         abort(400, "Failed to retrieve the Type of an Object from the database!")
@@ -576,14 +560,14 @@ def get_cmdb_object_mds_references(public_id: int, request_user: CmdbUser) -> Re
                                                             AccessControlPermission.READ)
 
             if not referenced_object:
-                abort(404, f"The Object with ID:{public_id} was not found!")
+                abort(404, f"The Object with ID:{object_id} was not found!")
 
             referenced_object = CmdbObject.from_data(referenced_object)
 
             referenced_type = objects_manager.get_object_type(referenced_object.get_type_id())
 
             if not referenced_type:
-                abort(404, f"The Type of the Object with ID:{public_id} was not found in the database!")
+                abort(404, f"The Type of the Object with ID:{object_id} was not found in the database!")
 
             mds_reference = CmdbMultiRender([referenced_object], request_user, True).get_mds_reference(object_id)
 
@@ -740,14 +724,20 @@ def get_unstructured_cmdb_objects(public_id: int, request_user: CmdbUser) -> Res
         if not object_type:
             abort(404, f"Type with ID: {public_id} not found!")
 
-        all_type_objects: list[CmdbObject] = objects_manager.find_objects(criteria={'type_id': public_id})
+        # Only the field names are needed to detect structural drift, so project them server-side
+        # instead of loading every full object document
+        all_type_objects: list[dict[str, Any]] = objects_manager.find_objects(
+            criteria={'type_id': public_id},
+            as_dict=True,
+            projection={'public_id': 1, 'fields.name': 1},
+        )
 
         type_fields = {field.get('name') for field in object_type.fields}
 
         unstructured: list[int] = [
-            obj.get_public_id()
+            obj['public_id']
             for obj in all_type_objects
-            if {f["name"] for f in obj.fields} != type_fields
+            if {f.get('name') for f in obj.get('fields', [])} != type_fields
         ]
 
         return GetListResponse(unstructured, body=request.method == 'HEAD').make_response()
@@ -765,13 +755,12 @@ def get_unstructured_cmdb_objects(public_id: int, request_user: CmdbUser) -> Res
 
 # --------------------------------------------------- CRUD - UPDATE -------------------------------------------------- #
 
-#TODO: REFACTOR-FIX (reduce complexity)
 @objects_blueprint.route('/<int:public_id>', methods=['PUT', 'PATCH'])
 @insert_request_user
 @verify_api_access(required_api_level=ApiLevel.ADMIN)
 @objects_blueprint.protect(auth=True, right='base.framework.object.edit')
 @objects_blueprint.validate(CmdbObject.SCHEMA)
-def update_cmdb_object(public_id: int, data: dict, request_user: CmdbUser):
+def update_cmdb_object(public_id: int, data: dict, request_user: CmdbUser) -> Response:
     """
     HTTP `PUT`/`PATCH` route to update one or more CmdbObjects with the same payload
 
@@ -795,142 +784,28 @@ def update_cmdb_object(public_id: int, data: dict, request_user: CmdbUser):
     try:
         logs_manager: LogsManager = ManagerProvider.get_manager(ManagerType.LOGS, request_user)
         objects_manager: ObjectsManager = ManagerProvider.get_manager(ManagerType.OBJECTS, request_user)
+        types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
 
-        object_ids = request.args.getlist('objectIDs')
-
+        object_ids: list[int] = request.args.getlist('objectIDs')
         object_ids = list(map(int, object_ids)) if object_ids else [public_id]
 
-        # The active flag comes from the shared request body and applies to every target object
-        active_state = request.get_json().get('active', None)
+        # The active flag comes from the shared (validated) payload and applies to every target
+        active_state = data.get('active', None)
 
-        results: list[dict] = []
-
-        for obj_id in object_ids:
-            new_data = copy.deepcopy(data)
-
-            current_object_instance: CmdbObject | None = objects_manager.get_object(
+        # DataGerry sends the complete object on every update (no PATCH/subset semantics), so the
+        # same payload is applied to each target; apply_object_update runs the per-object side effects
+        results: list[dict[str, Any]] = [
+            apply_object_update(
                 obj_id,
+                data,
+                active_state,
                 request_user,
-                AccessControlPermission.READ,
-                as_dict=False
-            )
-
-            if not current_object_instance:
-                abort(404, f"Object with ID:{obj_id} not found!")
-
-            if is_special_type_changed(current_object_instance.special_type, new_data.get('special_type')):
-                abort(400, f"SpecialType of an Object is not changable. Occured for Object with ID: {obj_id}")
-
-            current_type_instance = objects_manager.get_object_type(current_object_instance.get_type_id())
-
-            if not current_type_instance:
-                abort(500, "Type of Object not found in database!")
-
-            current_object_render_result = CmdbMultiRender(
-                [current_object_instance],
-                request_user
-            ).result(single_object=True)
-
-            new_data.update({
-                'public_id': obj_id,
-                'creation_time': current_object_instance.creation_time,
-                'author_id': current_object_instance.author_id,
-                'active': active_state if active_state in [True, False] else current_object_instance.active,
-                'version': data.get('version', current_object_instance.version),
-                'last_edit_time': datetime.now(timezone.utc),
-                'editor_id': request_user.public_id,
-            })
-
-            old_fields = list(map(lambda x: {k: v for k, v in x.items() if k in ['name', 'value']},
-                                current_object_render_result.fields))
-
-            new_fields = data['fields']
-            for item in new_fields:
-                for old in old_fields:
-                    if item['name'] == old['name']:
-                        old['value'] = item['value']
-            new_data['fields'] = old_fields
-
-            update_comment = new_data.pop('comment', "")
-
-            # Validate fields have type
-            validate_and_fill_object_fields(objects_manager, new_data)
-
-            types_manager: TypesManager = ManagerProvider.get_manager(ManagerType.TYPES, request_user)
-
-            previous_object: dict[str, Any] = CmdbObject.to_json(current_object_instance)
-
-            # Editing an IPAM special-type object (or adding/changing an interface subnet) needs an IPAM license
-            guard_object_write_license(types_manager, request_user, new_data, previous_object)
-
-            ipam_errors: list[dict[str, Any]] = enforce_object_invariants(
                 objects_manager,
                 types_manager,
-                new_data,
-                previous_object=previous_object,
+                logs_manager,
             )
-
-            if ipam_errors:
-                abort(400, format_errors_for_abort(ipam_errors))
-
-            update_object_instance = CmdbObject(**json.loads(json.dumps(new_data, default=default),
-                                                            object_hook=object_hook))
-
-            # calc version
-            changes = current_object_instance / update_object_instance
-
-            if len(changes['new']) == 1:
-                version_type = update_object_instance.VERSIONING_PATCH
-            elif len(changes['new']) == len(update_object_instance.fields):
-                version_type = update_object_instance.VERSIONING_MAJOR
-            elif len(changes['new']) > (len(update_object_instance.fields) / 2):
-                version_type = update_object_instance.VERSIONING_MINOR
-            else:
-                version_type = update_object_instance.VERSIONING_PATCH
-            new_data['version'] = update_object_instance.update_version(version_type)
-
-            objects_manager.update_object(obj_id, new_data, request_user, AccessControlPermission.UPDATE)
-
-            results.append(new_data)
-
-            object_after = objects_manager.get_object(obj_id, request_user, AccessControlPermission.READ)
-
-            if not object_after:
-                abort(404, f"Updated Object with ID:{obj_id} not found in database!")
-
-            object_after: CmdbObject = CmdbObject.from_data(object_after)
-
-            # sync select fields
-            if object_after.has_fields_of_type(FieldType.SELECT):
-                sync_select_field_options(request_user, object_after, current_type_instance)
-
-            #EVENT: UPDATE-EVENT
-            try:
-                send_webhook_event(request_user,
-                                   WebhookEventType.UPDATE,
-                                   CmdbObject.to_json(current_object_instance),
-                                   CmdbObject.to_json(object_after),
-                                   changes)
-            except Exception as error:
-                LOGGER.error(
-                    "[update_cmdb_object] Send Webhook Event Exception: %s, Type:%s", error, type(error)
-                )
-
-            # Generate log entry
-            try:
-                log_data = {
-                    'object_id': obj_id,
-                    'version': update_object_instance.get_version(),
-                    'user_id': request_user.get_public_id(),
-                    'user_name': request_user.get_display_name(),
-                    'comment': update_comment,
-                    'changes': changes,
-                    'render_state': json.dumps(update_object_instance, default=default).encode('UTF-8')
-                }
-                logs_manager.insert_log(action=LogAction.EDIT, log_type=CmdbObjectLog.__name__, **log_data)
-            except Exception as error:
-                #TODO: ERROR-FIX
-                LOGGER.error("[update_cmdb_object] Failed to create Log. Error: %s", error)
+            for obj_id in object_ids
+        ]
 
         return UpdateMultiResponse(results=results).make_response()
     except HTTPException as http_err:
@@ -1047,7 +922,7 @@ def update_cmdb_object_state(public_id: int, request_user: CmdbUser) -> Response
         except Exception as error:
             LOGGER.error("[update_cmdb_object_state] Failed to create Log. Error: %s", error)
 
-        return UpdateSingleResponse(result=found_object.__dict__).make_response()
+        return UpdateSingleResponse(result=CmdbObject.to_json(found_object)).make_response()
     except HTTPException as http_err:
         raise http_err
     except ObjectsManagerGetError as err:
@@ -1257,7 +1132,7 @@ def delete_cmdb_object(public_id: int, request_user: CmdbUser) -> Response:
         abort(500, "Failed to delete Object references from the database!")
     except ObjectsManagerGetError as err:
         LOGGER.error("[delete_cmdb_object] ObjectsManagerGetError: %s", err, exc_info=True)
-        abort(500, "Failed to retrieve the requested Object from the database!")
+        abort(400, "Failed to retrieve the requested Object from the database!")
     except ObjectsManagerDeleteError as err:
         LOGGER.error("[delete_cmdb_object] ObjectsManagerDeleteError: %s", err, exc_info=True)
         abort(500, "Failed to delete the Object in the database!")

--- a/tests/unit/interface/rest_api/routes/cmdb_license/test_license_guard.py
+++ b/tests/unit/interface/rest_api/routes/cmdb_license/test_license_guard.py
@@ -23,6 +23,7 @@ exercised in isolation: cloud/local pass-through, feature present/absent, the mi
 guard, the 403 message, and the per-request lookup cache (including that it does not leak across
 requests)
 """
+import base64
 from http import HTTPStatus
 from typing import Any, Callable
 
@@ -32,7 +33,9 @@ from werkzeug.exceptions import HTTPException
 
 from cmdb.interface.rest_api.routes.cmdb_license import license_guard
 from cmdb.interface.rest_api.routes.cmdb_license.license_guard import (
+    BASIC_AUTH_HEADER_PREFIX,
     abort_if_feature_locked,
+    enforce_rest_api_license,
     feature_locked,
     gate_blueprint,
     request_has_feature,
@@ -46,6 +49,12 @@ HANDLER_RESULT: str = 'handler-ran'
 REQUEST_USER_SENTINEL: object = object()
 GATED_ROUTE: str = '/gated'
 VIEW_RESULT: str = 'view-ran'
+
+# Fixtures for the REST-API (Basic-auth) lock tests
+AUTHORIZATION_HEADER: str = 'Authorization'
+BASIC_AUTH_HEADER: str = BASIC_AUTH_HEADER_PREFIX + base64.b64encode(b'user:pass').decode('utf-8')
+BEARER_AUTH_HEADER: str = 'Bearer some.jwt.token'
+OPTIONS_METHOD: str = 'OPTIONS'
 
 
 class _StubLicenseService:
@@ -399,3 +408,117 @@ def test_abort_if_feature_locked_is_noop_when_licensed(
 
     with app.test_request_context():
         abort_if_feature_locked(GATED_FEATURE, REQUEST_USER_SENTINEL)  # must not raise
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                          enforce_rest_api_license (Basic-auth lock)                                  #
+# -------------------------------------------------------------------------------------------------------------------- #
+def test_rest_lock_blocks_basic_auth_when_unlicensed(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """On-premise, a Basic-auth request is blocked with 403 when REST_API is not licensed"""
+    install_service(set())
+
+    with app.test_request_context(headers={AUTHORIZATION_HEADER: BASIC_AUTH_HEADER}):
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_rest_api_license()
+
+    assert exc_info.value.code == HTTPStatus.FORBIDDEN
+
+
+def test_rest_lock_allows_basic_auth_when_licensed(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """On-premise, a Basic-auth request passes when REST_API is licensed"""
+    install_service({LicenseFeature.REST_API.value})
+
+    with app.test_request_context(headers={AUTHORIZATION_HEADER: BASIC_AUTH_HEADER}):
+        enforce_rest_api_license()  # must not raise
+
+
+def test_rest_lock_blocks_lowercase_basic_scheme_when_unlicensed(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """A lowercase 'basic ' scheme still authenticates upstream, so it must be gated too"""
+    install_service(set())
+    lowercase_basic_header: str = BASIC_AUTH_HEADER.lower()
+
+    with app.test_request_context(headers={AUTHORIZATION_HEADER: lowercase_basic_header}):
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_rest_api_license()
+
+    assert exc_info.value.code == HTTPStatus.FORBIDDEN
+
+
+def test_rest_lock_allows_bearer_even_when_unlicensed(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """A Bearer (JWT) request is never gated - the UI keeps working when REST_API is unlicensed"""
+    stub = install_service(set())
+
+    with app.test_request_context(headers={AUTHORIZATION_HEADER: BEARER_AUTH_HEADER}):
+        enforce_rest_api_license()  # must not raise
+
+    # The license is never consulted for a non-Basic request
+    assert stub.call_count == 0
+
+
+def test_rest_lock_allows_request_without_authorization_header(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """A request without an Authorization header (e.g. POST /auth/login) is never gated"""
+    stub = install_service(set())
+
+    with app.test_request_context():
+        enforce_rest_api_license()  # must not raise
+
+    assert stub.call_count == 0
+
+
+def test_rest_lock_does_not_block_options_preflight(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """An OPTIONS preflight carrying a Basic header is never gated and never consults the license"""
+    stub = install_service(set())
+
+    with app.test_request_context(
+        method=OPTIONS_METHOD,
+        headers={AUTHORIZATION_HEADER: BASIC_AUTH_HEADER},
+    ):
+        enforce_rest_api_license()  # must not raise
+
+    assert stub.call_count == 0
+
+
+def test_rest_lock_passes_through_in_cloud_mode(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """In cloud mode a Basic-auth request is never gated and the license is never consulted"""
+    app.cloud_mode = True
+    stub = install_service(set())
+
+    with app.test_request_context(headers={AUTHORIZATION_HEADER: BASIC_AUTH_HEADER}):
+        enforce_rest_api_license()  # must not raise
+
+    assert stub.call_count == 0
+
+
+def test_rest_lock_passes_through_in_local_mode(
+    app: Flask,
+    install_service: Callable[[set[str]], _StubLicenseService],
+) -> None:
+    """In local mode a Basic-auth request is never gated and the license is never consulted"""
+    app.local_mode = True
+    stub = install_service(set())
+
+    with app.test_request_context(headers={AUTHORIZATION_HEADER: BASIC_AUTH_HEADER}):
+        enforce_rest_api_license()  # must not raise
+
+    assert stub.call_count == 0

--- a/tests/unit/interface/rest_api/routes/framework_routes/test_objects_helper.py
+++ b/tests/unit/interface/rest_api/routes/framework_routes/test_objects_helper.py
@@ -20,6 +20,7 @@ Pure tests: no Mongo. The render path patches RenderList at the helper module pa
 validation helper drives a MagicMock ObjectsManager. Only the helpers' own branch logic is
 exercised (view dispatch, the type-schema / field-name guards, the special_type comparison)
 """
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -33,12 +34,35 @@ from cmdb.interface.rest_api.routes.framework_routes.cmdb_objects.objects_helper
     validate_and_fill_object_fields,
     guard_object_write_license,
     guard_object_delete_license,
+    to_normalized_cmdb_object,
+    build_new_object_data,
+    compute_object_version,
+    emit_object_update_events,
+    apply_object_update,
+    sync_select_field_options,
+    handle_delete_object_location,
 )
 from cmdb.interface.rest_api.routes.framework_routes.cmdb_objects.objects_constants import ObjectViewMode
+from cmdb.models.object_model import CmdbObject
+from cmdb.models.type_model.field_type_enum import FieldType
 from cmdb.security.license.license_constants import LicenseFeature
 # -------------------------------------------------------------------------------------------------------------------- #
 
 HELPER_PATH: str = 'cmdb.interface.rest_api.routes.framework_routes.cmdb_objects.objects_helper'
+
+
+def _make_object(fields: list[dict[str, Any]], special_type: Any = None, public_id: int = 1) -> CmdbObject:
+    """Builds a minimal valid CmdbObject for the helper unit tests."""
+    return CmdbObject(
+        public_id=public_id,
+        type_id=1,
+        version='1.0.0',
+        creation_time=datetime.now(timezone.utc),
+        author_id=1,
+        active=True,
+        fields=fields,
+        special_type=special_type,
+    )
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -201,3 +225,305 @@ class TestGuardObjectDeleteLicense:
             guard_object_delete_license(MagicMock(), MagicMock(), {})
 
         guard.assert_not_called()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              to_normalized_cmdb_object                                               #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestToNormalizedCmdbObject:
+    """to_normalized_cmdb_object rebuilds a CmdbObject from a payload via a BSON-safe round-trip."""
+
+    def test_builds_cmdb_object_preserving_core_fields(self) -> None:
+        """The returned CmdbObject carries the payload's type_id and fields (datetimes survive)."""
+        payload = {
+            'public_id': 4,
+            'type_id': 7,
+            'version': '1.0.0',
+            'creation_time': datetime.now(timezone.utc),
+            'author_id': 3,
+            'active': True,
+            'fields': [{'name': 'a', 'value': 1, 'type': 'text'}],
+        }
+
+        result = to_normalized_cmdb_object(payload)
+
+        assert isinstance(result, CmdbObject)
+        assert result.type_id == 7
+        assert result.fields == [{'name': 'a', 'value': 1, 'type': 'text'}]
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                build_new_object_data                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestBuildNewObjectData:
+    """build_new_object_data normalises the insert payload (id / type / defaults / version)."""
+
+    @staticmethod
+    def _manager(new_id: int = 111, existing: Any = None, object_type: Any = 'a-type') -> MagicMock:
+        """A MagicMock ObjectsManager driving the id / existence / type-resolution branches."""
+        manager = MagicMock()
+        manager.get_new_object_public_id.return_value = new_id
+        manager.get_object.return_value = existing
+        manager.get_object_type.return_value = object_type
+        return manager
+
+    def test_assigns_new_public_id_and_defaults(self) -> None:
+        """Without a supplied public_id a fresh id is assigned and active / version / time defaulted."""
+        manager = self._manager(new_id=111)
+
+        with patch(f'{HELPER_PATH}.validate_and_fill_object_fields') as validate:
+            new_data, object_type = build_new_object_data(manager, {'type_id': 5, 'fields': []})
+
+        assert new_data['public_id'] == 111
+        assert new_data['active'] is True
+        assert new_data['version'] == '1.0.0'
+        assert 'creation_time' in new_data
+        assert object_type == 'a-type'
+        validate.assert_called_once()
+
+    def test_supplied_existing_public_id_aborts_400(self) -> None:
+        """A supplied public_id that already exists is rejected with 400."""
+        manager = self._manager(existing={'public_id': 9})
+
+        with patch(f'{HELPER_PATH}.validate_and_fill_object_fields'):
+            with pytest.raises(HTTPException) as exc_info:
+                build_new_object_data(manager, {'public_id': 9, 'type_id': 5, 'fields': []})
+
+        assert exc_info.value.code == 400
+
+    def test_unknown_type_aborts_404(self) -> None:
+        """When the referenced type does not exist the request is rejected with 404."""
+        manager = self._manager(object_type=None)
+
+        with patch(f'{HELPER_PATH}.validate_and_fill_object_fields'):
+            with pytest.raises(HTTPException) as exc_info:
+                build_new_object_data(manager, {'type_id': 5, 'fields': []})
+
+        assert exc_info.value.code == 404
+
+    def test_preserves_supplied_active_flag(self) -> None:
+        """An explicit active flag in the payload is preserved (not overwritten to True)."""
+        manager = self._manager()
+
+        with patch(f'{HELPER_PATH}.validate_and_fill_object_fields'):
+            new_data, _ = build_new_object_data(manager, {'type_id': 5, 'active': False, 'fields': []})
+
+        assert new_data['active'] is False
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               compute_object_version                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestComputeObjectVersion:
+    """compute_object_version picks the version bump from the field-level diff size."""
+
+    @pytest.mark.parametrize('field_count,changed_count,expected_attr', [
+        (3, 1, 'VERSIONING_PATCH'),   # a single changed field is a patch
+        (3, 3, 'VERSIONING_MAJOR'),   # all fields changed is a major
+        (4, 3, 'VERSIONING_MINOR'),   # more than half (but not all) is a minor
+        (4, 2, 'VERSIONING_PATCH'),   # not >half, not all, not one -> patch
+    ])
+    def test_bump_selection(self, field_count: int, changed_count: int, expected_attr: str) -> None:
+        """The correct VERSIONING_* constant is passed to update_version for each diff size."""
+        base_fields = [{'name': f'f{i}', 'value': i} for i in range(field_count)]
+        current = _make_object(base_fields)
+
+        updated_fields = [dict(field) for field in base_fields]
+        for i in range(changed_count):
+            updated_fields[i] = {'name': f'f{i}', 'value': 1000 + i}
+        updated = _make_object(updated_fields)
+
+        updated.update_version = MagicMock(return_value='bumped')
+
+        new_version, changes = compute_object_version(current, updated)
+
+        assert new_version == 'bumped'
+        assert len(changes['new']) == changed_count
+        updated.update_version.assert_called_once_with(getattr(CmdbObject, expected_attr))
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             emit_object_update_events                                                #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestEmitObjectUpdateEvents:
+    """emit_object_update_events fires the webhook and writes the edit log, each best-effort."""
+
+    def test_emits_webhook_and_log(self) -> None:
+        """Both the update webhook and the edit log are produced on the happy path."""
+        logs_manager = MagicMock()
+        before = _make_object([{'name': 'a', 'value': 1}])
+        after = _make_object([{'name': 'a', 'value': 2}])
+        updated = _make_object([{'name': 'a', 'value': 2}])
+
+        with patch(f'{HELPER_PATH}.send_webhook_event') as webhook:
+            emit_object_update_events(MagicMock(), logs_manager, before, after, updated, {'new': []}, "note")
+
+        webhook.assert_called_once()
+        logs_manager.insert_log.assert_called_once()
+
+    def test_webhook_failure_does_not_block_log(self) -> None:
+        """A webhook error is swallowed and the edit log is still written."""
+        logs_manager = MagicMock()
+        obj = _make_object([{'name': 'a', 'value': 1}])
+
+        with patch(f'{HELPER_PATH}.send_webhook_event', side_effect=RuntimeError("boom")):
+            emit_object_update_events(MagicMock(), logs_manager, obj, obj, obj, {'new': []}, "")
+
+        logs_manager.insert_log.assert_called_once()
+
+    def test_log_failure_is_swallowed(self) -> None:
+        """A logging error never propagates out of the helper."""
+        logs_manager = MagicMock()
+        logs_manager.insert_log.side_effect = RuntimeError("boom")
+        obj = _make_object([{'name': 'a', 'value': 1}])
+
+        with patch(f'{HELPER_PATH}.send_webhook_event'):
+            emit_object_update_events(MagicMock(), logs_manager, obj, obj, obj, {'new': []}, "")  # must not raise
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                              sync_select_field_options                                               #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestSyncSelectFieldOptions:
+    """sync_select_field_options appends new free-text select values back onto the CmdbType."""
+
+    @staticmethod
+    def _object_type() -> MagicMock:
+        """A type carrying one select field 'os' whose only known option is 'Windows'."""
+        object_type = MagicMock()
+        object_type.public_id = 1
+        object_type.get_fields_with_type.return_value = {
+            'os': {'name': 'os', 'type': FieldType.SELECT, 'options': [{'name': 'Windows', 'label': 'Windows'}]}
+        }
+        object_type.fields = [
+            {'name': 'os', 'type': FieldType.SELECT, 'options': [{'name': 'Windows', 'label': 'Windows'}]}
+        ]
+        return object_type
+
+    def test_new_value_is_appended_and_type_persisted(self) -> None:
+        """An object select value unknown to the type is added as a new option and the type saved."""
+        object_type = self._object_type()
+        target_object = SimpleNamespace(
+            fields=[{'name': 'os', 'type': FieldType.SELECT, 'value': 'Linux'}],
+            multi_data_sections=[],
+        )
+        types_manager = MagicMock()
+
+        with patch(f'{HELPER_PATH}.ManagerProvider.get_manager', return_value=types_manager):
+            sync_select_field_options(MagicMock(), target_object, object_type)
+
+        types_manager.update_type.assert_called_once()
+        assert {opt['name'] for opt in object_type.fields[0]['options']} == {'Windows', 'Linux'}
+
+    def test_known_value_does_not_persist(self) -> None:
+        """When every select value is already a known option the type is not written."""
+        object_type = self._object_type()
+        target_object = SimpleNamespace(
+            fields=[{'name': 'os', 'type': FieldType.SELECT, 'value': 'Windows'}],
+            multi_data_sections=[],
+        )
+        types_manager = MagicMock()
+
+        with patch(f'{HELPER_PATH}.ManagerProvider.get_manager', return_value=types_manager):
+            sync_select_field_options(MagicMock(), target_object, object_type)
+
+        types_manager.update_type.assert_not_called()
+
+    def test_new_value_from_mds_row_is_appended(self) -> None:
+        """A new select value carried inside a multi-data-section row is also captured."""
+        object_type = self._object_type()
+        target_object = SimpleNamespace(
+            fields=[],
+            multi_data_sections=[{'values': [{'data': [{'name': 'os', 'type': FieldType.SELECT, 'value': 'Linux'}]}]}],
+        )
+        types_manager = MagicMock()
+
+        with patch(f'{HELPER_PATH}.ManagerProvider.get_manager', return_value=types_manager):
+            sync_select_field_options(MagicMock(), target_object, object_type)
+
+        types_manager.update_type.assert_called_once()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                             handle_delete_object_location                                            #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestHandleDeleteObjectLocation:
+    """handle_delete_object_location deletes a childless location and refuses a parent one with 400."""
+
+    def test_deletes_childless_location(self) -> None:
+        """A location with no children is removed."""
+        locations_manager = MagicMock()
+        locations_manager.get_location_for_object.return_value = {'public_id': 50}
+        locations_manager.get_one_by.return_value = None
+
+        with patch(f'{HELPER_PATH}.ManagerProvider.get_manager', return_value=locations_manager):
+            handle_delete_object_location(MagicMock(), 5)
+
+        locations_manager.delete_location.assert_called_once_with(50)
+
+    def test_parent_location_aborts_400(self) -> None:
+        """A location that still parents other locations is refused with 400 (business rule)."""
+        locations_manager = MagicMock()
+        locations_manager.get_location_for_object.return_value = {'public_id': 50}
+        locations_manager.get_one_by.return_value = [{'public_id': 60}]
+
+        with patch(f'{HELPER_PATH}.ManagerProvider.get_manager', return_value=locations_manager):
+            with pytest.raises(HTTPException) as exc_info:
+                handle_delete_object_location(MagicMock(), 5)
+
+        assert exc_info.value.code == 400
+        locations_manager.delete_location.assert_not_called()
+
+    def test_no_location_is_noop(self) -> None:
+        """When the object has no location nothing is deleted."""
+        locations_manager = MagicMock()
+        locations_manager.get_location_for_object.return_value = None
+
+        with patch(f'{HELPER_PATH}.ManagerProvider.get_manager', return_value=locations_manager):
+            handle_delete_object_location(MagicMock(), 5)
+
+        locations_manager.delete_location.assert_not_called()
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                apply_object_update                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestApplyObjectUpdate:
+    """apply_object_update guards the per-object update before touching the write path."""
+
+    def test_missing_object_aborts_404(self) -> None:
+        """A target object that no longer exists aborts with 404 before any write."""
+        objects_manager = MagicMock()
+        objects_manager.get_object.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            apply_object_update(5, {'fields': []}, None, MagicMock(),
+                                objects_manager, MagicMock(), MagicMock())
+
+        assert exc_info.value.code == 404
+        objects_manager.update_object.assert_not_called()
+
+    def test_special_type_change_aborts_400(self) -> None:
+        """Changing an object's special_type is refused with 400."""
+        objects_manager = MagicMock()
+        objects_manager.get_object.return_value = _make_object([{'name': 'a', 'value': 1}], special_type='SUBNET')
+
+        with pytest.raises(HTTPException) as exc_info:
+            apply_object_update(5, {'fields': [], 'special_type': 'VLAN'}, None, MagicMock(),
+                                objects_manager, MagicMock(), MagicMock())
+
+        assert exc_info.value.code == 400
+        objects_manager.update_object.assert_not_called()
+
+    def test_missing_type_aborts_500(self) -> None:
+        """When the object's type cannot be resolved the update aborts with 500."""
+        objects_manager = MagicMock()
+        objects_manager.get_object.return_value = _make_object([{'name': 'a', 'value': 1}])
+        objects_manager.get_object_type.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            apply_object_update(5, {'fields': []}, None, MagicMock(),
+                                objects_manager, MagicMock(), MagicMock())
+
+        assert exc_info.value.code == 500
+        objects_manager.update_object.assert_not_called()

--- a/tests/unit/interface/rest_api/routes/framework_routes/test_objects_routes.py
+++ b/tests/unit/interface/rest_api/routes/framework_routes/test_objects_routes.py
@@ -32,9 +32,12 @@ from werkzeug.exceptions import HTTPException
 from cmdb.interface.rest_api.routes.framework_routes.cmdb_objects.objects_routes import (
     get_cmdb_object_state,
     get_cmdb_object_references,
+    get_cmdb_object_mds_references,
     group_cmdb_objects_by_type_id,
     update_cmdb_object,
+    delete_cmdb_object,
 )
+from cmdb.errors.manager.objects_manager import ObjectsManagerGetError
 # -------------------------------------------------------------------------------------------------------------------- #
 
 ROUTE_PATH: str = 'cmdb.interface.rest_api.routes.framework_routes.cmdb_objects.objects_routes'
@@ -129,8 +132,8 @@ class TestGroupObjectsByTypeId:
         """A group whose type resolves to None is omitted; a valid group is enriched and returned."""
         del patched_manager_provider
         mgr.group_objects_by_value.return_value = [{'_id': 1, 'count': 3}, {'_id': 2, 'count': 1}]
-        # type_id 1 is orphaned (None), type_id 2 resolves to a real type
-        mgr.get_object_type.side_effect = [None, SimpleNamespace(label='Server', ci_explorer_color='#fff')]
+        # type_id 1 is orphaned (absent from the lookup), type_id 2 resolves to a real type
+        mgr.get_types_lookup.return_value = {2: SimpleNamespace(label='Server', ci_explorer_color='#fff')}
 
         with patch(f'{ROUTE_PATH}.fetch_only_active_objects', return_value=False), \
              patch(f'{ROUTE_PATH}.DefaultResponse') as response_ctor:
@@ -167,3 +170,47 @@ class TestUpdateCmdbObjectNotFoundMessage:
 
         assert exc_info.value.code == 404
         assert str(target_id) in exc_info.value.description
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                   get_cmdb_object_mds_references message (B3)                                        #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestMdsReferencesMissingIdMessage:
+    """A missing id in the objectIDs list yields a 404 naming that id, not the path public_id."""
+
+    def test_missing_id_message_uses_object_id(
+        self, flask_app: Flask, mgr: MagicMock, patched_manager_provider: Any,
+    ) -> None:
+        """When a requested objectID is missing, the 404 message references that id."""
+        del patched_manager_provider
+        mgr.get_object.return_value = None
+        path_id, target_id = 5, 4242
+
+        with flask_app.test_request_context(
+            f'/{path_id}/mds_references', query_string={'objectIDs': str(target_id)},
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _unwrap(get_cmdb_object_mds_references)(public_id=path_id, request_user=SimpleNamespace(public_id=1))
+
+        assert exc_info.value.code == 404
+        assert str(target_id) in exc_info.value.description
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                     delete_cmdb_object get-error mapping (B5)                                        #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TestDeleteCmdbObjectGetErrorMapping:
+    """A get failure resolving the delete target maps to 400, aligned with the sibling delete routes."""
+
+    def test_get_error_returns_400(
+        self, flask_app: Flask, mgr: MagicMock, patched_manager_provider: Any,
+    ) -> None:
+        """ObjectsManagerGetError while fetching the target aborts 400 (previously 500)."""
+        del patched_manager_provider
+        mgr.get_object.side_effect = ObjectsManagerGetError("boom")
+
+        with flask_app.test_request_context(f'/{MISSING_ID}', method='DELETE'):
+            with pytest.raises(HTTPException) as exc_info:
+                _unwrap(delete_cmdb_object)(public_id=MISSING_ID, request_user=SimpleNamespace(public_id=1))
+
+        assert exc_info.value.code == 400


### PR DESCRIPTION
Changes:
* lock external api without license
* improved object routes